### PR TITLE
Unzip .egg file by default

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -67,5 +67,6 @@ setup(
     install_requires=['numpy>=1.2.0', 'scipy>=0.6.0'],
     entry_points={
         'console_scripts': ['gadma = gadma.core:main']
-    }
+    },
+    zip_safe=False
 )


### PR DESCRIPTION
By default unless some flags are set `setuptools` compresses the library while installing.
This makes `GADMA` unable to run on some systems as it depends on files in the library directory which can be a zip archive.
This PR add `setuptools` flag to never zip the installed library.