### PR TITLE
Fix ZeroDivisionError when Nanc is zero (Issue #23).

### DIFF
--- a/gadma/core/draw_and_generate_code.py
+++ b/gadma/core/draw_and_generate_code.py
@@ -179,13 +179,12 @@ def print_runs_summary(start_time, shared_dict, settings):
             theta = engine.get_theta(x, *settings.get_engine_args())
             Nanc = engine.get_N_ancestral_from_theta(theta)
             addit_str = f"(theta = {theta: .2f})"
-            if Nanc is not None:
-                Nanc = int(Nanc)
+            if Nanc is not None or Nanc == 0:
                 if settings.relative_parameters:
-                    addit_str += f" (Nanc = {Nanc: d})"
+                    addit_str += f" (Nanc = {int(Nanc)})"
                     model_str = engine.model.as_custom_string(x)
                 else:
-                    model_str = f" [Nanc = {Nanc: d}] "
+                    model_str = f" [Nanc = {int(Nanc)}] "
 #                    Tg = settings.time_for_generation or 1.0
                     x_translated = engine.model.translate_units(x, Nanc)
                     model_str += engine.model.as_custom_string(x_translated)


### PR DESCRIPTION
Size of ancestral population was translated to integer and used for translation. But in case when it was very small after translation it became zero and cause errors in following translation of parameters. Now size is always float and is showed as integer in printing only. Also there is additional check and if Nanc is zero for some reason then GADMA does not translate parameters at all.