### PR TITLE
Fix #42 and sorting function in utils

### DIFF
--- a/gadma/cli/settings_storage.py
+++ b/gadma/cli/settings_storage.py
@@ -399,8 +399,8 @@ class SettingsStorage(object):
         # 3.8 Units of time in drawings
         elif (name == 'units_of_time_in_drawing' or
                 name == 'const_of_time_in_drawing'):
-            d = {'generations': 1, 'years': 1, 'thousand years': 0.01,
-                 'thousands of years': 0.01, 'kya': 0.01}
+            d = {'generations': 1, 'years': 1, 'thousand years': 0.001,
+                 'thousands of years': 0.001, 'kya': 0.001}
             if name == 'units_of_time_in_drawing':
                 value = value.lower()
                 if value not in d:

--- a/gadma/optimizers/genetic_algorithm.py
+++ b/gadma/optimizers/genetic_algorithm.py
@@ -373,7 +373,7 @@ class GeneticAlgorithm(GlobalOptimizer, ConstrainedOptimizer):
         if Y_gen is None:
             Y_gen = [f(x) for x in X_gen]
         # Sort by value of fitness
-        X_gen, Y_gen = sort_by_other_list(X_gen, Y_gen, reverse=self.maximize)
+        X_gen, Y_gen = sort_by_other_list(X_gen, Y_gen, reverse=False)
 
         # Simple checks
         assert len(X_gen[0]) == len(variables)

--- a/gadma/utils/utils.py
+++ b/gadma/utils/utils.py
@@ -63,7 +63,7 @@ def sort_by_other_list(x, y, reverse=False, key=None):
         return x
     if key is None:
         key = ident
-    sort_zip = sorted(zip(x, y), key=lambda p: key(p[1]))
+    sort_zip = sorted(zip(x, y), key=lambda p: key(p[1]), reverse=reverse)
     return [p[0] for p in sort_zip], [p[1] for p in sort_zip]
 
 

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -274,7 +274,7 @@ class TestCLI(unittest.TestCase):
         settings.units_of_time_in_drawing = 'YeArs'
         self.assertRaises(ValueError, settings.__setattr__,
                           'units_of_time_in_drawing', 'strange_value')
-        settings.const_of_time_in_drawing = 0.01
+        settings.const_of_time_in_drawing = 0.001
         self.assertEqual(settings.units_of_time_in_drawing, 'thousand years')
         settings.const_of_time_in_drawing = 100
         self.assertEqual(settings.const_of_time_in_drawing, 1.0)


### PR DESCRIPTION
Fix error in const for 'thousand of years' in plots (Issue #42) and reverse option in sorting function.