### PR TITLE
New engine: fastsimcoal2

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -50,3 +50,5 @@ dist/*
 # GitEye files
 /.project
 /Test Results - pytest_for_tests.html
+/model_from_GADMA.png
+/tests/test_data/DATA/vcf_ld/vcf_data_few_chr.h5

--- a/.gitignore
+++ b/.gitignore
@@ -45,3 +45,8 @@ gadma/version.py
 build/*
 gadma.egg-info/*
 dist/*
+/.idea/workspace.xml
+
+# GitEye files
+/.project
+/Test Results - pytest_for_tests.html

--- a/.idea/.gitignore
+++ b/.idea/.gitignore
@@ -1,0 +1,6 @@
+# Default ignored files
+/shelf/
+/workspace.xml
+/usage.statistics.xml
+dictionaries
+shelf

--- a/.idea/GADMA.iml
+++ b/.idea/GADMA.iml
@@ -1,0 +1,17 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<module type="PYTHON_MODULE" version="4">
+  <component name="NewModuleRootManager">
+    <content url="file://$MODULE_DIR$">
+      <excludeFolder url="file://$MODULE_DIR$/venv" />
+    </content>
+    <orderEntry type="inheritedJdk" />
+    <orderEntry type="sourceFolder" forTests="false" />
+  </component>
+  <component name="PyDocumentationSettings">
+    <option name="format" value="PLAIN" />
+    <option name="myDocStringFormat" value="Plain" />
+  </component>
+  <component name="TestRunnerService">
+    <option name="PROJECT_TEST_RUNNER" value="py.test" />
+  </component>
+</module>

--- a/.idea/GADMA.iml
+++ b/.idea/GADMA.iml
@@ -4,7 +4,7 @@
     <content url="file://$MODULE_DIR$">
       <excludeFolder url="file://$MODULE_DIR$/venv" />
     </content>
-    <orderEntry type="inheritedJdk" />
+    <orderEntry type="jdk" jdkName="Python 3.8 (GADMA)" jdkType="Python SDK" />
     <orderEntry type="sourceFolder" forTests="false" />
   </component>
   <component name="PyDocumentationSettings">

--- a/.idea/inspectionProfiles/GADMA.xml
+++ b/.idea/inspectionProfiles/GADMA.xml
@@ -1,0 +1,24 @@
+<component name="InspectionProjectProfileManager">
+  <profile version="1.0">
+    <option name="myName" value="GADMA" />
+    <inspection_tool class="PyCompatibilityInspection" enabled="true" level="WARNING" enabled_by_default="true">
+      <option name="ourVersions">
+        <value>
+          <list size="1">
+            <item index="0" class="java.lang.String" itemvalue="3.8" />
+          </list>
+        </value>
+      </option>
+    </inspection_tool>
+    <inspection_tool class="PyPackageRequirementsInspection" enabled="true" level="WARNING" enabled_by_default="true">
+      <option name="ignoredPackages">
+        <value>
+          <list size="2">
+            <item index="0" class="java.lang.String" itemvalue="dadi" />
+            <item index="1" class="java.lang.String" itemvalue="momi" />
+          </list>
+        </value>
+      </option>
+    </inspection_tool>
+  </profile>
+</component>

--- a/.idea/inspectionProfiles/profiles_settings.xml
+++ b/.idea/inspectionProfiles/profiles_settings.xml
@@ -1,0 +1,7 @@
+<component name="InspectionProjectProfileManager">
+  <settings>
+    <option name="PROJECT_PROFILE" value="GADMA" />
+    <option name="USE_PROJECT_PROFILE" value="false" />
+    <version value="1.0" />
+  </settings>
+</component>

--- a/.idea/markdown.xml
+++ b/.idea/markdown.xml
@@ -1,0 +1,9 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<project version="4">
+  <component name="MarkdownSettings">
+    <enabledExtensions>
+      <entry key="MermaidLanguageExtension" value="false" />
+      <entry key="PlantUMLLanguageExtension" value="false" />
+    </enabledExtensions>
+  </component>
+</project>

--- a/.idea/misc.xml
+++ b/.idea/misc.xml
@@ -1,0 +1,4 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<project version="4">
+  <component name="ProjectRootManager" version="2" project-jdk-name="Python 3.8 (GADMA)" project-jdk-type="Python SDK" />
+</project>

--- a/.idea/modules.xml
+++ b/.idea/modules.xml
@@ -1,0 +1,8 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<project version="4">
+  <component name="ProjectModuleManager">
+    <modules>
+      <module fileurl="file://$PROJECT_DIR$/.idea/GADMA.iml" filepath="$PROJECT_DIR$/.idea/GADMA.iml" />
+    </modules>
+  </component>
+</project>

--- a/.idea/pylint.xml
+++ b/.idea/pylint.xml
@@ -1,0 +1,6 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<project version="4">
+  <component name="PylintConfigService">
+    <option name="scanBeforeCheckin" value="false" />
+  </component>
+</project>

--- a/.idea/vcs.xml
+++ b/.idea/vcs.xml
@@ -1,0 +1,6 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<project version="4">
+  <component name="VcsDirectoryMappings">
+    <mapping directory="$PROJECT_DIR$" vcs="Git" />
+  </component>
+</project>

--- a/gadma/cli/settings_storage.py
+++ b/gadma/cli/settings_storage.py
@@ -8,6 +8,7 @@ from ..data import SFSDataHolder, \
 from ..engines import get_engine, MomentsEngine, MomentsLdEngine
 from ..engines import DadiEngine
 from ..engines import all_engines, all_drawing_engines
+from ..engines.fsc2_engine import FastSimCoal2InputFiles
 from ..models import StructureDemographicModel, CustomDemographicModel
 from ..optimizers import get_local_optimizer, get_global_optimizer
 from ..optimizers import LinearConstrain
@@ -219,7 +220,9 @@ class SettingsStorage(object):
                          'const_for_mutation_rate', 'vmin',
                          'parameter_identifiers', 'migration_masks']
         exist_file_attrs = ['input_data', 'custom_filename',
-                            'bed_file', "preprocessed_data"]
+                            'bed_file', "preprocessed_data",
+                            'fsc2_template_file', 'fsc2_estimation_file',
+                            'fsc2_definition_file']
         exist_dir_attrs = ['directory_with_bootstrap',
                            'resume_from', 'recombination_maps']
         empty_dir_attrs = ['output_directory']
@@ -1325,6 +1328,18 @@ class SettingsStorage(object):
                 recombination_rate=rec_rate,
                 fixed_anc_size=self.fixed_ancestral_size,
                 has_anc_size=self.ancestral_size_as_parameter
+            )
+        elif all([self.engine == 'fsc2',
+                  self.fsc2_template_file is not None,
+                  self.fsc2_estimation_file is not None,
+                  self.fsc2_definition_file is not None]):
+            return CustomDemographicModel(
+                function=FastSimCoal2InputFiles(self.template_file,
+                                                self.estimation_file,
+                                                self.definition_file),
+                # FastSimCoal2Engine doesn't use `variables` explicitly,
+                # but I don't know if it's used elsewhere during the execution in this engine's case
+                variables=None
             )
         else:
             raise ValueError("Some settings are missed so no model is "

--- a/gadma/code_generator/fsc2_generator.py
+++ b/gadma/code_generator/fsc2_generator.py
@@ -1,0 +1,388 @@
+import io
+from io import StringIO
+from os import PathLike
+from pathlib import Path
+from typing import NoReturn, Union, Any, Optional, Tuple, List, Callable, Final, Literal
+
+import numpy as np
+from numpy import ndarray
+
+DataType = Literal['dna', 'microsat', 'standard', 'freq',
+                   'DNA', 'MICROSAT', 'STANDARD', 'FREQ']
+
+
+def _ndarray_to_multiline_str(array: ndarray, formatter: Optional[dict] = None) -> str:
+    """
+    Turn a NumPy array into a string.
+
+    Example --  this array::
+
+        array([[1, 2],
+               [3, 4]])
+
+    ...is turned into::
+
+        1 2
+        3 4
+
+    :param array: Array to convert
+    :param formatter: Formatter passed to ``numpy.array2string``
+    :return: NumPy array as a string
+    """
+    matrix: str = np.array2string(array, separator=' ', formatter=formatter)
+    matrix = matrix.replace('[', '')
+    matrix = matrix.replace(']', '')
+    matrix = matrix.replace('\n ', '\n')
+    return matrix
+
+
+def _format_as_fsc2_keyword(value: Union[int, float, str]) -> Union[int, float, str]:
+    """Formats input as a fastsimcoal2 keyword, if the input is a string"""
+    if isinstance(value, str) and not value.endswith('$'):
+        return value + '$'
+    return value
+
+
+class FSC2InputFile(object):
+    """Base class for fastsimcoal2 input files."""
+    def __init__(self):
+        self._path: Optional[Path] = None
+        self.file: StringIO = io.StringIO()
+
+    def write(self, line: str) -> NoReturn:
+        self.file.write(f'{line}\n')
+
+    @property
+    def path(self) -> str:
+        return str(self._path)
+
+    def write_comment(self, comment: str) -> NoReturn:
+        """Write a comment to the file."""
+        self.write(f'// {comment}')
+
+    def save_to_file(self, path: Union[str, PathLike]) -> NoReturn:
+        """Save in-memory representation of the input file in filesystem"""
+        self._path = Path(path)
+        self._path.write_text(self.file.getvalue())
+
+
+class TemplateFile(FSC2InputFile):
+    """Class for fastsimcoal2 template files."""
+    def write_number_of_population_samples(self, samples: int) -> NoReturn:
+        """Write the number of population samples to the file.
+
+        :param samples: Number of population samples"""
+        self.write_comment('Number of population samples (demes)')
+        self.write(f'{samples}')
+
+    def write_initial_effective_population_sizes(self, sizes: tuple) -> NoReturn:
+        """Write effective population sizes to the file.
+
+        :param sizes: Effective population sizes"""
+        self.write_comment('Population effective sizes (number of genes)')
+        self._write_multiline_data(sizes)
+
+    def write_sample_sizes(self, sizes: tuple) -> NoReturn:
+        self.write_comment('Sample sizes')
+        self._write_multiline_data(sizes)
+
+    def write_initial_growth_rates(self, rates: Tuple[Union[str, int, float], ...]) -> NoReturn:
+        self.write_comment('Growth rates (negative growth implies population expansion)')
+        self._write_multiline_data(rates)
+
+    def _write_multiline_data(self, data: Tuple[Union[str, int, float], ...]) -> NoReturn:
+        """Write data that spans multiple lines.
+
+        :param data: data to write"""
+        for point in data:
+            if isinstance(point, (float, int)):
+                self.write(f'{str(point)}')
+            else:
+                self.write(f'{_format_as_fsc2_keyword(str(point))}')
+
+    def write_migration_matrices(self, matrices: Tuple[ndarray, ...]) -> NoReturn:
+        self.write_comment('Number of migration matrices. 0 implies no migration between demes')
+        self.write(f'{len(matrices)}')
+        for array, n in zip(matrices, range(0, len(matrices))):
+            if array.ndim > 2:
+                raise ValueError(f'arrays should be 2-dimensional. Offending array\'s index: {n}')
+            self.write_comment(f'migration matrix {n}')
+            formatter: dict = {'str_kind': lambda x: _format_as_fsc2_keyword(x)}
+            matrix = _ndarray_to_multiline_str(array, formatter)
+            self.write(f'{matrix}')
+
+    def write_multiple_events(self, events: Tuple[dict, ...]) -> NoReturn:
+        """
+        Write historical events to the template file.
+
+        :param events: A tuple containing dictionaries that describe the events.
+
+        Each dictionary should contain following keys:
+
+        * ``time``
+        * ``source``
+        * ``sink``
+        * ``migrants``
+        * ``new_sink_size``
+
+        Optional keys:
+
+        * ``new_sink_growth_rate`` (default value: ``'keep'``)
+        * ``new_migration_matrix`` (default value: ``'keep'``)
+        * ``no_migrations`` (default value: ``False``)
+        """
+        self.write_comment('hist. event: time, source, sink, migrants, '
+                           'new size, new growth rate, migr. matrix')
+        self.write(f'{len(events)} historical events')
+        for event in events:
+            self._write_event(**event)
+
+    def _write_event(self,
+                     time: Union[float, str],
+                     source: int,
+                     sink: int,
+                     migrants: Union[float, str],
+                     new_sink_size: Union[float, str],
+                     new_sink_growth_rate: Union[float, str] = 'keep',
+                     new_migration_matrix: Union[int, str] = 'keep',
+                     no_migrations: bool = False,
+                     absolute_resize: bool = True) -> NoReturn:
+        """
+        Write a line containing event details.
+
+        :param time: Number of generations *t* before
+            present at which the historical event happened.
+        :param source: Source deme (the first listed deme has index 0).
+        :param sink: Destination (sink) deme.
+        :param migrants: Expected proportion of migrants to move
+            from source to sink. Note that this proportion is not
+            fixed, and that it also represents the probability
+            for each lineage in the source deme to
+            migrate to the sink deme.
+        :param new_sink_size: New size for the **sink** deme,
+            relative to its size at generation *t*.
+            If ``absolute_resize`` is ``True``, this is treated
+            as an absolute value instead of a relative one.
+        :param new_sink_growth_rate: New growth rate for the **sink** deme.
+        :param new_migration_matrix: New migration matrix
+            to be used further back in time.
+        :param no_migrations: If ``True``, migrations
+            between demes are suppressed until the end
+            of the current coalescent simulation. If
+            next in line historical events were to specify
+            the use of some new migration matrix, this
+            would be ignored by fastsimcoal.
+        :param absolute_resize: If ``True``, ``new_sink_size`` is treated
+            as an absolute value. ``True`` by default.
+        """
+        time = _format_as_fsc2_keyword(time)
+        migrants = _format_as_fsc2_keyword(migrants)
+        new_sink_size = _format_as_fsc2_keyword(new_sink_size)
+        if new_sink_growth_rate != 'keep':
+            new_sink_growth_rate = _format_as_fsc2_keyword(new_sink_growth_rate)
+        if new_migration_matrix != 'keep':
+            new_migration_matrix = _format_as_fsc2_keyword(new_migration_matrix)
+
+        event: str = (f'{time} {source} {sink} {migrants} '
+                      f'{new_sink_size} {new_sink_growth_rate} {new_migration_matrix}')
+        if no_migrations:
+            event += ' nomig'
+        if absolute_resize:
+            event += ' absoluteResize'
+        self.write(f'{event}')
+
+    def write_chromosomes(self,
+                          number_of_chromosomes: int,
+                          different_structure: bool = False) -> NoReturn:
+        """
+        Write chromome data to the file.
+
+        :param number_of_chromosomes: Number of independent chromosomes.
+        :param different_structure: Specifies whether chromosomes have a different structure.
+        """
+        if different_structure:
+            different_structure = 1
+        else:
+            different_structure = 0
+        self.write_comment('Number of independent loci/chromosome')
+        self.write(f'{number_of_chromosomes} {different_structure}')
+
+    def write_chromosome_blocks(self, blocks: int) -> NoReturn:
+        """
+        Write number of chromosome blocks to the template file.
+
+        :param blocks: Number of chromosome blocks
+        """
+        self.write_comment('Number of linkage blocks per chromosome')
+        self.write(f'{blocks}\n')
+
+    def write_block_properties(self,
+                               data_type: DataType,
+                               markers: Union[int, str],
+                               recombination_rate: Union[float, str],
+                               **kwargs) -> NoReturn:
+        """
+        Write properties of a single chromosome block.
+
+        :param data_type: Type of data.
+        Possible values are: ``dna``, ``microsat``, ``standard``, ``freq``.
+        :param markers: Number of markers with this data type
+        to be simulated. For DNA, this is the sequence length.
+        :param recombination_rate: Recombination rate
+        between adjacent markers (between adjacent nucleotides for DNA).
+
+        ------
+
+        Optional arguments:
+
+        ``mutation_rate``
+            (*float* or *string*) Mutation rate per basepair (for 'dna' data type),
+            per locus (for 'microsat' data type), per marker (for 'standard' data type).
+
+        ``transition_rate``
+            (*float* or *string*) Transition rate
+            (fraction of substitutions that are transitions).
+            A value of 0.33 implies no transition bias.
+
+            Use with ``data_type = 'dna'``.
+
+        ``geometric_parameter``
+            (*float* or *string*) Value of the geometric parameter
+            for a Generalized Stepwise Mutation (GSM) model.
+            This value represents the proportion of mutations
+            that will change the allele size by more than one step.
+
+            Values between 0 and 1 are required.
+
+            A value of 0 is for a strict Stepwise Mutation Model (SMM).
+
+            Use with ``data_type = 'microsat'``.
+        """
+        data_type = data_type.lower()
+        markers = _format_as_fsc2_keyword(markers)
+        recombination_rate = _format_as_fsc2_keyword(recombination_rate)
+
+        if data_type == 'dna':
+            mutation_rate: Union[float, str] = _format_as_fsc2_keyword(kwargs['mutation_rate'])
+            transition_rate: Union[float, str] = _format_as_fsc2_keyword(kwargs['transition_rate'])
+        elif data_type == 'microsat':
+            mutation_rate: Union[float, str] = _format_as_fsc2_keyword(kwargs['mutation_rate'])
+            geometric_parameter: Union[float, str] = _format_as_fsc2_keyword(kwargs['geometric_parameter'])
+            if not 0 <= geometric_parameter <= 1:
+                raise ValueError('geometric_parameter out of bounds [0, 1]')
+        elif data_type == 'standard':
+            mutation_rate: Union[float, str] = _format_as_fsc2_keyword(kwargs['mutation_rate'])
+        elif data_type == 'freq':
+            mutation_rate: float = np.format_float_positional(kwargs['mutation_rate'])
+
+        output: str = f'{data_type.upper()} {markers} {recombination_rate} {mutation_rate}'
+
+        if data_type == 'dna':
+            output += f' {transition_rate}'
+        elif data_type == 'microsat':
+            output += f' {geometric_parameter}'
+        self.write(output)
+
+
+class EstimationFile(FSC2InputFile):
+    """Class for fastsimcoal2 estimation files."""
+    def __init__(self):
+        super().__init__()
+        self.write_comment('Priors and rules file')
+        self.write_comment('*********************')
+
+    # TODO: Implement the `padding`
+    def write_parameters(self, parameters: List[dict], padded: bool = False) -> NoReturn:
+        """
+        Write parameters.
+
+        :param parameters: List of parameters to write. Each parameter is defined by a dictionary
+            (see FSC2EstimationFile._write_single_parameter method for keys and value types).
+        :param padded: [Unused] Make the output neatly aligned using whitespace padding.
+        """
+        self.write('[PARAMETERS]')
+        self.write_comment('#isInt? #name    #dist.  #min #max')
+        for p in parameters:
+            self._write_single_parameter(**p)
+        self.write('\n')
+
+    def _write_single_parameter(self,
+                                is_int: bool,
+                                name: str,
+                                dist: str,
+                                minimum: Union[float, int],
+                                maximum: Union[float, int],
+                                output: bool,
+                                bounded: bool) -> NoReturn:
+        """
+        Write a single parameter to the file.
+
+        :param is_int: Flag to indicate whether the parameter is an integer.
+        :param name: Name of the parameter.
+        :param dist: Distribution of the parameter.
+        :param minimum: Minimum value.
+        :param maximum: Maximum value.
+        :param output: Flag to indicate whether to output the optimized parameter value or not.
+        :param bounded:
+        """
+        is_int, name, output, bounded = self._process_arguments(is_int, name, output, bounded)
+        self.write(f'{is_int} {name} {dist} {minimum} {maximum} {output} {bounded}')
+
+    @staticmethod
+    def _process_arguments(is_int: bool,
+                           name: str,
+                           output: bool,
+                           bounded: bool = None) -> Tuple[int, str, str, str]:
+        if is_int:
+            is_int = 1
+        else:
+            is_int = 0
+        name = _format_as_fsc2_keyword(name)
+        if output:
+            output = 'output'
+        else:
+            output = 'hide'
+        if bounded:
+            bounded = 'bounded'
+        else:
+            bounded = ''
+        return is_int, name, output, bounded
+
+    def write_complex_parameters(self, parameters: List[dict]) -> NoReturn:
+        """
+        Write complex parameters.
+
+        :param parameters: List of parameters. Each parameter should be a dictionary
+            (see :py:meth:`_write_single_complex_parameter` for keys).
+        """
+        self.write('[COMPLEX PARAMETERS]')
+        for p in parameters:
+            self._write_single_complex_parameter(**p)
+
+    def _write_single_complex_parameter(self,
+                                        is_int: bool,
+                                        name: str,
+                                        definition: str,
+                                        output: bool) -> NoReturn:
+        is_int, name, output, _ = self._process_arguments(is_int, name, output)
+        self.write(f'{is_int} {name} = {definition} {output}')
+
+
+class DefinitionFile(FSC2InputFile):
+    """Class for fastsimcoal2 definition files."""
+    def __init__(self, parameters_names: Tuple[str, ...], parameters_values: Union[ndarray, list]):
+        super().__init__()
+        self.parameters_names: tuple = tuple(_format_as_fsc2_keyword(n)
+                                             for n in parameters_names)
+        self.parameters_values: Union[ndarray, list] = parameters_values
+
+        delimiter = ' '
+        self.write(delimiter.join(self.parameters_names))
+        self.write_parameters_values()
+
+    def write_parameters_values(self):
+        if isinstance(self.parameters_values, ndarray):
+            values = _ndarray_to_multiline_str(self.parameters_values)
+        else:
+            values = ' '.join(str(v) for v in self.parameters_values)
+        self.write(values)

--- a/gadma/code_generator/fsc2_generator.py
+++ b/gadma/code_generator/fsc2_generator.py
@@ -63,7 +63,7 @@ class FSC2InputFile(object):
     def save_to_file(self, path: Union[str, PathLike]) -> NoReturn:
         """Save in-memory representation of the input file in filesystem"""
         self._path = Path(path)
-        self._path.write_text(self.file.getvalue())
+        self._path.write_text(self.file.getvalue(), encoding='utf-8')
 
 
 class TemplateFile(FSC2InputFile):

--- a/gadma/engines/__init__.py
+++ b/gadma/engines/__init__.py
@@ -7,3 +7,4 @@ from .moments_ld_engine import MomentsLdEngine, extract_rec_map_name_and_extensi
 from .dadi_moments_common import DadiOrMomentsEngine  # NOQA
 from .demes_engine import DemesEngine  # NOQA
 from .momi_engine import MomiEngine  # NOQA
+from .fsc2_engine import FastSimCoal2Engine  # NOQA

--- a/gadma/engines/fsc2_engine.py
+++ b/gadma/engines/fsc2_engine.py
@@ -1,9 +1,7 @@
-import io
 import os
 import re
 import shutil
 import tempfile
-from io import StringIO
 from math import log
 from pathlib import Path
 from typing import Final, Union, List, Dict, NoReturn, Tuple, Callable, Optional, ClassVar, NamedTuple, Sequence, \

--- a/gadma/engines/fsc2_engine.py
+++ b/gadma/engines/fsc2_engine.py
@@ -421,9 +421,8 @@ class FastSimCoal2Engine(Engine):
         self.data_holder.outgroup = None
 
     @classmethod
-    def _read_data(cls, data_holder: SFSDataHolder) -> Any:
-        data = data_holder.filename
-        return data
+    def _read_data(cls, data_holder: SFSDataHolder) -> inner_data_type:
+        return data_holder.filename
 
     def _get_growth_rate_for_population(self,
                                         values: ParameterValues,

--- a/gadma/engines/fsc2_engine.py
+++ b/gadma/engines/fsc2_engine.py
@@ -329,10 +329,8 @@ class FastSimCoal2Engine(Engine):
             if is_msfs(self.data_holder):
                 args.append('--multiSFS')
 
-            fsc2_stdout: StringIO = io.StringIO()
-
             print([f.name for f in Path(workdir).iterdir()])
-            self.run_fsc2(FSC2_PATH, args, workdir=workdir, stdout=fsc2_stdout)
+            self.run_fsc2(FSC2_PATH, args, workdir=workdir)
             print('-' * 80)
 
             likelihood = _find_max_obs_lhood(workdir, self.PREFIX)
@@ -485,15 +483,13 @@ class FastSimCoal2Engine(Engine):
     @staticmethod
     def run_fsc2(fsc2_path: str,
                  args: List[str],
-                 workdir: Union[str, os.PathLike],
-                 stdout: StringIO = None) -> NoReturn:
+                 workdir: Union[str, os.PathLike]) -> NoReturn:
         """
-        Run fastsimcoal2 with specified arguments. Also captures standard output.
+        Run fastsimcoal2 with specified arguments.
 
         :param fsc2_path: Path to fastsimcoal2 binary file.
         :param args: Arguments to pass to fastsimcoal2.
         :param workdir: Working directory for calculations.
-        :param stdout: IO stream for writing standard output.
         """
         # TODO: Come up with a way to use the `subprocess` library
         assert Path(fsc2_path).exists(), "Can't find fsc2 binary"

--- a/gadma/engines/fsc2_engine.py
+++ b/gadma/engines/fsc2_engine.py
@@ -217,7 +217,9 @@ def _find_max_obs_lhood(workdir, prefix) -> float:
 
 def _new_sfs_name(sfs_file_name: str, base_name: str) -> str:
     """
-    Replaces the base name (or adds one if absent) of an fsc2 SFS file.
+    Replaces the base name (or adds one if absent) of an fsc2 SFS file
+    with another base name. Mainly used to conform all input files for
+    fastsimcoal2 to a single format, so that it actually recognises them.
 
     Accepted input file name formats:
 
@@ -267,7 +269,13 @@ class FastSimCoal2InputFiles(NamedTuple):
 
 
 class FastSimCoal2Engine(Engine):
-    """Class representing the fastsimcoal2 engine"""
+    """
+    Class representing the fastsimcoal2 engine
+
+    **Note:** when passing SFS data to the engine,
+    files with more than two observed samples should be multidimensional SFS
+    (refer to `fastsimcoal2 manual <http://cmpg.unibe.ch/software/fastsimcoal2/man/fastsimcoal27.pdf>`_ for details).
+    """
     id: ClassVar = 'fsc2'
     supported_models: Final = [CustomDemographicModel,
                                EpochDemographicModel,

--- a/gadma/engines/fsc2_engine.py
+++ b/gadma/engines/fsc2_engine.py
@@ -40,7 +40,7 @@ class FastSimCoal2Engine(Engine):
     id: Final[str] = 'fsc2'
     supported_models: Final[list] = [EpochDemographicModel,
                                      TreeDemographicModel]
-    supported_data: Final[list] = [SFSDataHolder]
+    supported_data: Final[list] = [SFSDataHolder]  # TODO: Edit the failed tests to skip the VCFDataHolder check
     inner_data_type = str
 
     can_evaluate = True
@@ -55,6 +55,11 @@ class FastSimCoal2Engine(Engine):
                              " use set_and_evaluate function instead.")
 
         var2value = self._process_values(values)
+
+        # TODO: Implement a check for a CustomDemographicModel
+        # The CustomDemographicModel should have a tuple with paths to fsc2 input files.
+        # If self.model is CustomDemographicModel, skip fsc2 input file generation
+        # and pass them straight to the fsc2 call.
 
         fsc2_model, values = self._get_fsc2_model(values)
         self.set_model(fsc2_model)
@@ -367,6 +372,8 @@ class FastSimCoal2Engine(Engine):
             os.system(command)
 
     def update_data_holder_with_inner_data(self):
+        # TODO: Code for processing inner data goes here
+        # See gadma.engines.momi_engine.MomiEngine.update_data_holder_with_inner_data
         pass
 
     @classmethod

--- a/gadma/engines/fsc2_engine.py
+++ b/gadma/engines/fsc2_engine.py
@@ -9,6 +9,7 @@ from pathlib import Path
 from typing import Final, Union, List, Dict, NoReturn, Tuple, Callable, Optional, ClassVar, NamedTuple
 
 import numpy as np
+from dadi import Spectrum
 from numpy import ndarray
 
 from . import Engine, register_engine
@@ -254,7 +255,7 @@ def _new_sfs_name(sfs_file_name: str, base_name: str) -> str:
     return new_name
 
 
-def _infer_sample_sizes(sfs_data) -> Tuple[int, ...]:
+def _infer_sample_sizes(sfs_data: Spectrum) -> Tuple[int, ...]:
     """
     Infer sample sizes from the observed SFS file.
     :return: Sample sizes.
@@ -432,7 +433,7 @@ class FastSimCoal2Engine(Engine):
         return file
 
     @property
-    def sfs_data(self):
+    def sfs_data(self) -> Spectrum:
         from gadma.engines.dadi_moments_common import read_sfs_data
         import dadi
         data_holder = self.data_holder if self.data_holder is not None else SFSDataHolder(self.inner_data)

--- a/gadma/engines/fsc2_engine.py
+++ b/gadma/engines/fsc2_engine.py
@@ -96,7 +96,8 @@ class FastSimCoal2Engine(Engine):
         with tempfile.TemporaryDirectory(prefix=f'{self.PREFIX}_') as workdir:
             sfs_name = Path(self.data).name
             new_sfs_name = self._new_sfs_name(sfs_name, self.PREFIX)
-            shutil.copy(self.data, Path(workdir, new_sfs_name))
+            new_sfs_path = Path(workdir, new_sfs_name)
+            shutil.copy(self.data, new_sfs_path)
 
             if isinstance(self.model, TreeDemographicModel):
                 tpl_file, est_file, def_file = self.generate_code(var2value)

--- a/gadma/engines/fsc2_engine.py
+++ b/gadma/engines/fsc2_engine.py
@@ -121,7 +121,8 @@ class FastSimCoal2Engine(Engine):
 
             fsc2_stdout: StringIO = io.StringIO()
 
-            self.run_fsc2(FSC2_PATH, args, cwd=workdir, stdout=fsc2_stdout)
+            print([f.name for f in Path(workdir).iterdir()])
+            self.run_fsc2(FSC2_PATH, args, workdir=workdir, stdout=fsc2_stdout)
             print('-' * 80)
 
             likelihood = self._find_max_obs_lhood(workdir, self.PREFIX)
@@ -403,24 +404,24 @@ class FastSimCoal2Engine(Engine):
     @staticmethod
     def run_fsc2(fsc2_path: str,
                  args: List[str],
-                 cwd: Union[str, os.PathLike],
+                 workdir: Union[str, os.PathLike],
                  stdout: StringIO = None) -> NoReturn:
         """
         Run fastsimcoal2 with specified arguments. Also captures standard output.
 
         :param fsc2_path: Path to fastsimcoal2 binary file.
         :param args: Arguments to pass to fastsimcoal2.
-        :param cwd: Working directory for calculations.
+        :param workdir: Working directory for calculations.
         :param stdout: IO stream for writing standard output.
         """
         # TODO: Come up with a way to use the `subprocess` library
         assert Path(fsc2_path).exists(), "Can't find fsc2 binary"
         args: str = " ".join([str(e) for e in args])
-        command = f"cd {cwd}; {fsc2_path} {args}"
+        command = f"cd {workdir}; {fsc2_path} {args}"
         print(command)
         os.system(command)
         # with redirect_stdout(stdout):
-        #     retcode = subprocess.call([fsc2_path, args], shell=True, cwd=cwd)
+        #     retcode = subprocess.call([fsc2_path, args], shell=True, cwd=workdir)
 
     def update_data_holder_with_inner_data(self):
         # TODO: Code for processing inner data goes here

--- a/gadma/engines/fsc2_engine.py
+++ b/gadma/engines/fsc2_engine.py
@@ -9,7 +9,7 @@ from contextlib import redirect_stdout
 from io import StringIO
 from math import log
 from pathlib import Path
-from typing import Final, Union, List, Dict, NoReturn, Tuple, Any, Callable, Optional
+from typing import Final, Union, List, Dict, NoReturn, Tuple, Callable, Optional, ClassVar
 
 import numpy as np
 from numpy import ndarray
@@ -48,15 +48,18 @@ def is_msfs(data_holder: SFSDataHolder):
 
 class FastSimCoal2Engine(Engine):
     """Class representing the fastsimcoal2 engine"""
-    id: Final[str] = 'fsc2'
-    supported_models: Final[list] = [CustomDemographicModel,
-                                     EpochDemographicModel,
-                                     TreeDemographicModel]
+    id: ClassVar = 'fsc2'
+    supported_models: Final = [CustomDemographicModel,
+                               EpochDemographicModel,
+                               TreeDemographicModel]
     # TODO: Edit the failed tests to skip the VCFDataHolder check
-    supported_data: Final[list] = [SFSDataHolder]
-    inner_data_type = str
+    supported_data: Final = [SFSDataHolder]
+    inner_data_type: Final = str
 
-    can_evaluate = True
+    can_evaluate: Final = True
+
+    data: inner_data_type
+    data_holder: SFSDataHolder
 
     PREFIX: Final[str] = 'gadma_fsc2'
 

--- a/gadma/engines/fsc2_engine.py
+++ b/gadma/engines/fsc2_engine.py
@@ -24,6 +24,8 @@ from ..models import CustomDemographicModel
 from ..models.variables_combinations import Addition, Division
 from ..code_generator.fsc2_generator import EstimationFile, TemplateFile, DefinitionFile
 
+LINE = ("\n" + "-" * 80 + "\n")
+
 EpochModelEvent = Union[Epoch, Split]
 TreeModelEvent = Union[Leaf, LineageMovement, PopulationSizeChange]
 Model = Union[EpochDemographicModel, TreeDemographicModel]
@@ -91,6 +93,7 @@ class FastSimCoal2Engine(Engine):
         with tempfile.TemporaryDirectory(prefix=f'{self.PREFIX}_') as workdir:
             sfs_name = Path(self.data).name
             new_sfs_name = self._new_sfs_name(sfs_name, self.PREFIX)
+            print(f'{sfs_name} -> {new_sfs_name}', end=LINE)
             new_sfs_path = Path(workdir, new_sfs_name)
             shutil.copy(self.data, new_sfs_path)
 

--- a/gadma/engines/fsc2_engine.py
+++ b/gadma/engines/fsc2_engine.py
@@ -291,13 +291,13 @@ class FastSimCoal2Engine(Engine):
 
         var2value = self._process_values(values)
 
-        fsc2_model, values = self._get_fsc2_model(values)
-        self.model = fsc2_model
-
         if isinstance(self.model, CustomDemographicModel):
             assert (isinstance(self.model.function, FastSimCoal2InputFiles)
                     and all(isinstance(elem, (str, os.PathLike)) for elem in self.model.function))
             tpl_file, est_file, def_file = self.model.function
+        else:
+            fsc2_model, values = _get_fsc2_model(self.model, values)
+            self.model = fsc2_model
 
         with tempfile.TemporaryDirectory(prefix=f'{self.PREFIX}_') as workdir:
             sfs_name = Path(self.data).name

--- a/gadma/engines/fsc2_engine.py
+++ b/gadma/engines/fsc2_engine.py
@@ -234,8 +234,12 @@ class FastSimCoal2Engine(Engine):
         return tuple(growth_rates)
 
     def _leaves(self):
-        return [event for event in self.model.events
-                if isinstance(event, Leaf)]
+        leaves = []
+        for event in self.model.events:
+            if isinstance(event, Leaf):
+                leaves.append(event)
+        leaves.sort(key=lambda leaf: leaf.pop)
+        return leaves
 
     # Unused
     @property

--- a/gadma/engines/fsc2_engine.py
+++ b/gadma/engines/fsc2_engine.py
@@ -558,15 +558,37 @@ class FastSimCoal2Engine(Engine):
         return max_obs_lhood
 
     @staticmethod
-    def _new_sfs_name(sfs_name: str, prefix: str) -> str:
-        pattern = re.compile(r'(.*)((?:_DAFpop0|_jointDAFpop1_0)\.obs)')
-        match = re.search(pattern, sfs_name)
-        if match:
-            new_name = f'{prefix}{match.group(2)}'
+    def _new_sfs_name(sfs_file_name: str, base_name: str) -> str:
+        """
+        Replaces the base name (or adds one if absent) of an fsc2 SFS file.
+
+        Accepted input file name formats:
+
+        * ``*DAFpop0.obs``, ``*_DAFpop0.obs``
+        * ``*jointDAFpop1_0.obs``, ``*_jointDAFpop1_0.obs``
+        * ``*DSFS.obs``, ``*_DSFS.obs``
+
+        :param sfs_file_name: Name of the file to be renamed. For expected formats see the list.
+        :param base_name: New base name of the file (usually something like "gadma_fsc2")
+
+        :return: New file name.
+
+        :raise ValueError: if *sfs_file_name* doesn't conform to expected file name formats.
+        """
+        pattern_ = re.compile(r'(.*)(_(?:DAFpop0|jointDAFpop1_0|DSFS)\.obs)')
+        pattern = re.compile(r'(.*)((?:DAFpop0|jointDAFpop1_0|DSFS)\.obs)')
+        match_ = re.search(pattern_, sfs_file_name)
+        match = re.search(pattern, sfs_file_name)
+        if match is not None:
+            # '*jointDAFpop1_0.obs' -> '{base_name}_jointDAFpop1_0.obs
+            suffix = match.group(2)
+            new_name = f'{base_name}_{suffix}'
+        elif match_ is not None:
+            # '*_jointDAFpop1_0.obs' -> '{base_name}_jointDAFpop1_0.obs
+            suffix = match_.group(2)
+            new_name = f'{base_name}{suffix}'
         else:
-            pattern = re.compile(r'(.*)((?:DAFpop0|jointDAFpop1_0)\.obs)')
-            match = re.search(pattern, sfs_name)
-            new_name = f'{prefix}_{match.group(2)}'
+            raise ValueError(f"File name {sfs_file_name} does not conform to expected format")
         return new_name
 
 

--- a/gadma/engines/fsc2_engine.py
+++ b/gadma/engines/fsc2_engine.py
@@ -298,13 +298,16 @@ class FastSimCoal2Engine(Engine):
                 new_sink_size = event.size_pop.name + '$'
                 new_sink_growth_rate: str = 'keep'
                 new_migration_matrix = 'keep'
-            fsc2_event["time"] = time
-            fsc2_event["source"] = source
-            fsc2_event["sink"] = sink
-            fsc2_event["migrants"] = migrants
-            fsc2_event["new_sink_size"] = new_sink_size
-            fsc2_event["new_sink_growth_rate"] = new_sink_growth_rate
-            fsc2_event["new_migration_matrix"] = new_migration_matrix
+            else:
+                raise RuntimeError(f'Wrong event type, expected types: '
+                                   f'{PopulationSizeChange, LineageMovement}')
+            fsc2_event.update({"time": time,
+                               "source": source,
+                               "sink": sink,
+                               "migrants": migrants,
+                               "new_sink_size": new_sink_size,
+                               "new_sink_growth_rate": new_sink_growth_rate,
+                               "new_migration_matrix": new_migration_matrix})
             fsc2_events.append(fsc2_event)
         return tuple(fsc2_events)
 

--- a/gadma/engines/fsc2_engine.py
+++ b/gadma/engines/fsc2_engine.py
@@ -15,8 +15,8 @@ import numpy as np
 from numpy import ndarray
 
 from . import Engine, register_engine
-from ..models import EpochDemographicModel, TreeDemographicModel, Epoch, Split, PopulationSizeChange, Leaf, \
-    LineageMovement
+from ..models import EpochDemographicModel, TreeDemographicModel, Epoch, Split, \
+    PopulationSizeChange, Leaf, LineageMovement
 
 from ..utils.variables import PopulationSizeVariable, TimeVariable, DynamicVariable
 from ..data import SFSDataHolder
@@ -156,7 +156,7 @@ class FastSimCoal2Engine(Engine):
             tpl_file.save_to_file(filename + f"{self.PREFIX}.tpl")
             est_file.save_to_file(filename + f"{self.PREFIX}.est")
             def_file.save_to_file(filename + f"{self.PREFIX}.def")
-            return
+            return None
         return tpl_file, est_file, def_file
 
     def _generate_template_file(self):
@@ -216,7 +216,7 @@ class FastSimCoal2Engine(Engine):
         sfs_file_data = sfs_file_data.expandtabs(1)
         sfs_file_data = StringIO(sfs_file_data)
         sfs: ndarray = np.genfromtxt(sfs_file_data, dtype=int, skip_header=2)
-        sfs = sfs[:, 1:]
+        sfs = sfs[:, 1:]  # FIXME
         sample_sizes: List[int] = list(sfs.shape)
         sample_sizes.reverse()
         return tuple(sample_sizes)
@@ -236,6 +236,7 @@ class FastSimCoal2Engine(Engine):
         return [event for event in self.model.events
                 if isinstance(event, Leaf)]
 
+    # Unused
     @property
     def _first_event(self):
         if self.model is None:
@@ -277,10 +278,12 @@ class FastSimCoal2Engine(Engine):
             fsc2_event = {}
             if isinstance(event, Leaf):
                 continue
+
             if isinstance(event.t, Addition):
                 time: str = self._time_to_complex_param(event.t)
             else:
                 time = event.t.name + '$'
+
             if isinstance(event, PopulationSizeChange):
                 source: int = event.pop
                 sink: int = event.pop
@@ -311,6 +314,7 @@ class FastSimCoal2Engine(Engine):
             fsc2_events.append(fsc2_event)
         return tuple(fsc2_events)
 
+    # Unused
     def _map_model_events(self,
                           model_tree_events: List[TreeModelEvent],
                           model_epoch_events: List[EpochModelEvent]) -> Dict[TreeModelEvent,

--- a/gadma/engines/fsc2_engine.py
+++ b/gadma/engines/fsc2_engine.py
@@ -27,7 +27,12 @@ TreeModelEvent = Union[Leaf, LineageMovement, PopulationSizeChange]
 Model = Union[EpochDemographicModel, TreeDemographicModel]
 ParameterValues = Union[List, Dict]
 
-FSC2_PATH = "/home/cafune/.local/bin/fsc2"  # TODO: Needs to be dynamically set up
+FSC2_PATH: Final[Optional[str]] = os.getenv('FSC2_PATH')
+
+
+def fsc2_available() -> bool:
+    if not FSC2_PATH:
+        return False
 
 
 class FastSimCoal2Engine(Engine):
@@ -529,8 +534,5 @@ class FastSimCoal2Engine(Engine):
         return new_name
 
 
-fsc2_available = True  # TODO: check for fsc2 availability
-# fsc2_available = Path(FSC2_PATH).exists()
-
-if fsc2_available:
+if Path(FSC2_PATH).exists():
     register_engine(FastSimCoal2Engine)

--- a/gadma/engines/fsc2_engine.py
+++ b/gadma/engines/fsc2_engine.py
@@ -86,7 +86,7 @@ class FastSimCoal2Engine(Engine):
         # and pass them straight to the fsc2 call.
 
         fsc2_model, values = self._get_fsc2_model(values)
-        self.set_model(fsc2_model)
+        self.model = fsc2_model
 
         if isinstance(self.model, CustomDemographicModel):
             assert (isinstance(self.model.function, FastSimCoal2InputFiles)

--- a/gadma/engines/fsc2_engine.py
+++ b/gadma/engines/fsc2_engine.py
@@ -404,8 +404,9 @@ class FastSimCoal2Engine(Engine):
 
     def update_data_holder_with_inner_data(self):
         # TODO: Code for processing inner data goes here
-        # See gadma.engines.momi_engine.MomiEngine.update_data_holder_with_inner_data
-        pass
+        self.data_holder.projections = self._infer_sample_sizes()
+        self.data_holder.population_labels = None
+        self.data_holder.outgroup = None
 
     @classmethod
     def _read_data(cls, data_holder: SFSDataHolder) -> Any:

--- a/gadma/engines/fsc2_engine.py
+++ b/gadma/engines/fsc2_engine.py
@@ -1,0 +1,536 @@
+import io
+import os
+import re
+import shutil
+import sys
+import tempfile
+from contextlib import redirect_stdout
+from io import StringIO
+from math import log
+from pathlib import Path
+from typing import Final, Union, List, Dict, NoReturn, Tuple, Any, Callable, Optional
+
+import numpy as np
+from numpy import ndarray
+
+from . import Engine, register_engine
+from ..models import EpochDemographicModel, TreeDemographicModel, Epoch, Split, PopulationSizeChange, Leaf, \
+    LineageMovement
+
+from ..utils.variables import PopulationSizeVariable, TimeVariable, DynamicVariable
+from .. import SFSDataHolder
+from ..models.variables_combinations import Addition, Division
+from ..code_generator.fsc2_generator import EstimationFile, TemplateFile, DefinitionFile
+
+EpochModelEvent = Union[Epoch, Split]
+TreeModelEvent = Union[Leaf, LineageMovement, PopulationSizeChange]
+Model = Union[EpochDemographicModel, TreeDemographicModel]
+ParameterValues = Union[List, Dict]
+
+FSC2_PATH = "/home/cafune/.local/bin/fsc2"  # TODO: Needs to be dynamically set up
+
+
+class FastSimCoal2Engine(Engine):
+    """Class representing the fastsimcoal2 engine"""
+    id: Final[str] = 'fsc2'
+    supported_models: Final[list] = [EpochDemographicModel,
+                                     TreeDemographicModel]
+    supported_data: Final[list] = [SFSDataHolder]
+    inner_data_type = str
+
+    can_evaluate = True
+
+    def __init__(self, data=None, model=None):
+        super().__init__(data, model)
+        self._fsc2_complex_parameters: Dict[str, str] = {}
+
+    def evaluate(self, values: ParameterValues, **options):
+        if self.data is None or self.model is None:
+            raise ValueError("Please set data and model for the engine or"
+                             " use set_and_evaluate function instead.")
+
+        var2value = self._process_values(values)
+
+        fsc2_model, values = self._get_fsc2_model(values)
+        self.set_model(fsc2_model)
+
+        prefix: str = 'gadma_fsc2'
+        with tempfile.TemporaryDirectory(prefix=prefix) as workdir:
+            sfs_name = Path(self.data).name
+            new_sfs_name = self._new_sfs_name(sfs_name, prefix)
+            shutil.copy(self.data, Path(workdir, new_sfs_name))
+
+            tpl_file, est_file, def_file = self.generate_code(var2value)
+            tpl_file.save_to_file(Path(workdir, f'{prefix}.tpl'))
+            est_file.save_to_file(Path(workdir, f'{prefix}.est'))
+            def_file.save_to_file(Path(workdir, f'{prefix}.def'))
+
+            n_simulations: int = options['n_sims'] if 'n_sims' in options else 1000
+            n_loops: int = options['n_loops'] if 'n_loops' in options else 20
+
+            args = ['-t', Path(tpl_file.path).name,  # template parameter file
+                    '-e', Path(est_file.path).name,  # parameter estimation file
+                    '-F', Path(def_file.path).name,  # definition file (for the fixed variables)
+                    '-d',                 # simulate SFS
+                    '-M',                 # estimation by composite max likelihood
+                    '-n', n_simulations,  # number of simulations
+                    '-L', n_loops]        # number of ECM cycles
+
+            fsc2_stdout: StringIO = io.StringIO()
+
+            self.run_fsc2(FSC2_PATH, args, cwd=workdir, stdout=fsc2_stdout)
+            print('-' * 80)
+
+            likelihood = self._find_max_obs_lhood(workdir, prefix)
+
+        return likelihood
+
+    def _process_values(self, values: ParameterValues) -> Dict:
+        """
+        Process demographic model parameter values for fsc2 usage.
+
+        :param values: Parameter values.
+        :return: Processed values.
+        """
+        var2value: dict = self.model.var2value(values)
+
+        n_anc_var = self.model.Nanc_size
+        n_anc = self.model.get_value_from_var2value(var2value, n_anc_var)
+
+        values = self.model.translate_values(
+            units="physical",
+            values=values,
+            Nanc=n_anc
+        )
+
+        return self.model.var2value(values)
+
+    def generate_code(self,
+                      values: ParameterValues,
+                      filename=None,
+                      nanc=None,
+                      gen_time=None,
+                      gen_time_units="years") -> Tuple[TemplateFile,
+                                                       EstimationFile,
+                                                       DefinitionFile]:
+        tpl_file = self._generate_template_file()
+        est_file = self._generate_estimation_file(values)
+        def_file = self._generate_definitions_file(values)
+
+        return tpl_file, est_file, def_file
+
+    def _generate_template_file(self):
+        file = TemplateFile()
+
+        current_n_of_pops: int = self._infer_n_of_populations()
+        file.write_number_of_population_samples(current_n_of_pops)
+
+        current_pop_sizes: Tuple = self._get_initial_pop_sizes()
+        file.write_initial_effective_population_sizes(current_pop_sizes)
+
+        sample_sizes: Tuple[int, ...] = self._infer_sample_sizes()
+        file.write_sample_sizes(sample_sizes)
+
+        initial_growth_rates: Tuple[Union[int, str]] = self._get_initial_growth_rates()
+        file.write_initial_growth_rates(initial_growth_rates)
+
+        matrices: Tuple[ndarray, ...] = tuple([self._zero_matrix])
+        file.write_migration_matrices(matrices)
+
+        events: Tuple[dict, ...] = self._get_events()
+        file.write_multiple_events(events)
+
+        file.write_chromosomes(number_of_chromosomes=1)
+        file.write_chromosome_blocks(blocks=1)
+        file.write_block_properties(data_type='FREQ', markers=1,
+                                    recombination_rate=0, mutation_rate=2.5e-8)
+        return file
+
+    def _infer_n_of_populations(self) -> int:
+        """
+        Infer number of populations from the name of the observed SFS file.
+        See fastsimcoal2 manual, Observed SFS file names
+
+        :return: Number of populations.
+        """
+        obs_sfs_filename = Path(self.inner_data).stem
+        if obs_sfs_filename.endswith(("DAFpop0", "MAFpop0")):
+            n_of_pops = 1
+        elif obs_sfs_filename.endswith(("jointDAFpop1_0", "jointMAFpop1_0")):
+            n_of_pops = 2
+        elif obs_sfs_filename.endswith("DSFS"):
+            raise ValueError("FastSimCoal2Engine doesn't support SFSs"
+                             "that have >2 dimensions")
+            # TODO: Make it support multiSFS
+        else:
+            raise ValueError("Invalid SFS name or not a supported SFS type")
+        return n_of_pops
+
+    def _infer_sample_sizes(self) -> Tuple[int, ...]:
+        """
+        Infer sample sizes from the observed SFS file.
+        :return: Sample sizes.
+        """
+        with open(self.inner_data, encoding="utf-8") as sfs_file:
+            sfs_file_data = sfs_file.read()
+        sfs_file_data = sfs_file_data.expandtabs(1)
+        sfs_file_data = StringIO(sfs_file_data)
+        sfs: ndarray = np.genfromtxt(sfs_file_data, dtype=int, skip_header=2)
+        sfs = sfs[:, 1:]
+        sample_sizes: List[int] = list(sfs.shape)
+        sample_sizes.reverse()
+        return tuple(sample_sizes)
+
+    def _get_initial_growth_rates(self) -> Tuple[Union[int, str], ...]:
+        leaves = self._leaves()
+        growth_rates = []
+        for leaf in leaves:
+            if leaf.g == 0:
+                growth_rate = leaf.g
+            else:
+                growth_rate = self._g_to_complex_param(leaf.g, leaf.dyn)
+            growth_rates.append(growth_rate)
+        return tuple(growth_rates)
+
+    def _leaves(self):
+        return [event for event in self.model.events
+                if isinstance(event, Leaf)]
+
+    @property
+    def _first_event(self):
+        if self.model is None:
+            raise RuntimeError(f"Attribute `model` of engine {self.id} has not been set.")
+        non_leaf_events = [e for e in self.model.events if not isinstance(e, Leaf)]
+        first_event = self.model.non_leaf_events[0]
+        return first_event
+
+    def _get_migration_matrices(self, values: ParameterValues) -> Tuple[ndarray, ...]:
+        """
+        Gathers all migration matrices in the model in a single tuple.
+        Also adds a zero matrix at the end of the tuple.
+        :param values: Model parameter values
+        :return: Migration matrices.
+        """
+        # TODO: Will have to write code for resizing all matrices to one size according to the population count
+        matrices = []
+        for event in self.model.events:
+            if isinstance(event, Epoch):
+                matrix: ndarray = event.mig_args.copy()
+                if matrix is None:
+                    continue
+                matrix = self.model.get_value_from_var2value(values, matrix)
+                matrices.append(matrix)
+        matrices += self._zero_matrix
+        return tuple(matrices)
+
+    @property
+    def _zero_matrix(self) -> ndarray:
+        leaf_count = len([e for e in self.model.events if isinstance(e, Leaf)])
+        zero_matrix = np.zeros([leaf_count, leaf_count], dtype=int)
+        return zero_matrix
+
+    def _get_events(self) -> Tuple[Dict[str, Union[str, int]], ...]:
+        model_events: list = self.model.events
+
+        fsc2_events = []
+        for event in model_events:
+            fsc2_event = {}
+            if isinstance(event, Leaf):
+                continue
+            if isinstance(event.t, Addition):
+                time: str = self._time_to_complex_param(event.t)
+            else:
+                time = event.t.name + '$'
+            if isinstance(event, PopulationSizeChange):
+                source: int = event.pop
+                sink: int = event.pop
+                migrants: int = 0
+                new_sink_size: str = event.size_pop.name + '$'
+                if event.g == 0:
+                    new_sink_growth_rate: int = 0
+                else:
+                    new_sink_growth_rate: str = self._g_to_complex_param(event.g, event.dyn)
+                new_migration_matrix = 0
+            elif isinstance(event, LineageMovement):
+                source = event.pop_from
+                sink = event.pop
+                migrants = 1
+                new_sink_size = event.size_pop.name + '$'
+                new_sink_growth_rate: str = 'keep'
+                new_migration_matrix = 'keep'
+            fsc2_event["time"] = time
+            fsc2_event["source"] = source
+            fsc2_event["sink"] = sink
+            fsc2_event["migrants"] = migrants
+            fsc2_event["new_sink_size"] = new_sink_size
+            fsc2_event["new_sink_growth_rate"] = new_sink_growth_rate
+            fsc2_event["new_migration_matrix"] = new_migration_matrix
+            fsc2_events.append(fsc2_event)
+        return tuple(fsc2_events)
+
+    def _map_model_events(self,
+                          model_tree_events: List[TreeModelEvent],
+                          model_epoch_events: List[EpochModelEvent]) -> Dict[TreeModelEvent,
+                                                                             EpochModelEvent]:
+        """
+        Map events of an ``TreeDemographicModel`` model
+        to its ``EpochDemographicModel`` counterpart
+
+        :param model_tree_events: Its tree-based counterpart events
+        :param model_epoch_events: Epoch-based demographic model events
+
+        :return: Dictionary with ``PopulationSizeChange`` and ``LineageMovement`` events
+            mapped to ``Epoch`` and ``Split`` events, accordingly.
+        """
+        event_mapping = {}
+        for tree_event in model_tree_events:
+            if isinstance(tree_event, Leaf):
+                continue
+            matching_event = self._find_matching_event(tree_event, model_epoch_events)
+            event_mapping[tree_event] = matching_event
+        return event_mapping
+
+    @staticmethod
+    def _find_matching_event(tree_event: TreeModelEvent,
+                             epoch_events: List[EpochModelEvent]) -> Optional[EpochModelEvent]:
+        """
+        Find all events in an ``EpochDemographicModel``
+        that match to the event from a ``TreeDemographicModel``
+
+        :param tree_event: A ``TreeDemographicModel`` event that is used for comparison
+        :param epoch_events: A list of ``EpochDemographicModel`` events that should be
+            searched for matching events
+        """
+        # TreeDemographicModel doesn't have an event for migration matrix switch.
+        # Therefore, this algorithm will not find a matching Epoch/Split,
+        # if there's an Epoch that has migration matrix switch as its only change
+        # compared to the Epoch after it.
+        # Which means that this change will not be recorded in the estimation file.
+        # TODO: Make a fix for this edge case
+        time: TimeVariable = tree_event.t.variables[-1]
+
+        def next_epoch_time(split: Split) -> Union[TimeVariable, int]:
+            event_index = epoch_events.index(split)
+            try:
+                event_after_index = event_index + 1
+                if not isinstance(epoch_events[event_after_index], Epoch):
+                    event_after_index += 1
+            except IndexError:
+                return 0
+            else:
+                return epoch_events[event_after_index].time_arg
+
+        def pop_size_change_condition(epoch: Epoch) -> bool:
+            return (isinstance(tree_event, PopulationSizeChange)
+                    and isinstance(epoch, Epoch)
+                    and epoch.time_arg == time)
+
+        def lineage_movement_condition(split: Split) -> bool:
+            return (isinstance(tree_event, LineageMovement)
+                    and isinstance(split, Split)
+                    and next_epoch_time(split) == time
+                    and split.pop_to_div == tree_event.pop_from)
+
+        if isinstance(tree_event, Leaf):
+            return None
+        for event in epoch_events:
+            if (pop_size_change_condition(event)
+                    or lineage_movement_condition(event)):
+                return event
+
+    @staticmethod
+    def run_fsc2(fsc2_path: str,
+                 args: List[str],
+                 cwd: Union[str, os.PathLike],
+                 stdout: StringIO = None) -> NoReturn:
+        """
+        Run fastsimcoal2 with specified arguments. Also captures standard output.
+
+        :param fsc2_path: Path to fastsimcoal2 binary file.
+        :param args: Arguments to pass to fastsimcoal2.
+        :param cwd: Working directory for calculations.
+        :param stdout: IO stream for writing standard output.
+        """
+        assert Path(fsc2_path).exists(), "Can't find fsc2 binary"
+        args = " ".join([str(e) for e in args])
+        command = f"cd {cwd}; {fsc2_path} {args}"  # TODO
+        if stdout:
+            with redirect_stdout(stdout):
+                os.system(command)
+                # subprocess.run([fsc2_path, *args], stdout=stdout)
+        else:
+            os.system(command)
+
+    def update_data_holder_with_inner_data(self):
+        pass
+
+    @classmethod
+    def _read_data(cls, data_holder: SFSDataHolder) -> Any:
+        data = data_holder.filename
+        return data
+
+    def _get_growth_rate_for_population(self,
+                                        values: ParameterValues,
+                                        pop: int,
+                                        epoch: Epoch) -> float:
+        # TODO: Rewrite with TreeModelEvent in mind
+        growth_rates = self._get_growth_rate(values, epoch)
+        return growth_rates[pop]
+
+    def _get_growth_rate(self,
+                         values: ParameterValues,
+                         event: TreeModelEvent) -> float:
+        # TODO: Rewrite with TreeModelEvent in mind
+        var2value: Callable = self.model.get_value_from_var2value
+
+        init_pop_sizes_vars: List[PopulationSizeVariable] = event.init_size_args
+        final_pop_sizes_vars: List[PopulationSizeVariable] = event.size_args
+        time_var: TimeVariable = event.time_arg
+
+        init_pop_sizes: Tuple = tuple(var2value(values, v) for v in init_pop_sizes_vars)
+        final_pop_sizes: Tuple = tuple(var2value(values, v) for v in final_pop_sizes_vars)
+        time: int = var2value(values, time_var)
+
+        growth_rates = []
+        for size_0, size_t in zip(final_pop_sizes, init_pop_sizes):
+            # Growth is exponential: N_t=N_0e^{rt}, where `r` is the growth rate.
+            # Therefore, r=\frac{\ln \left(\frac{N_t}{N_0}\right)}{t}
+            growth_rate = (log(size_t / size_0)) / time
+            growth_rates.append(growth_rate)
+        return growth_rates
+
+    def _get_fsc2_model(self, values: ParameterValues) -> Tuple[TreeDemographicModel,
+                                                                ParameterValues]:
+        model: TreeDemographicModel = self.model
+        if isinstance(self.model, EpochDemographicModel):
+            model, values = self.model.translate_to(TreeDemographicModel, values)
+        return model, values
+
+    def _get_initial_pop_sizes(self) -> Tuple:
+        """
+        Get population sizes at current time.
+        :returns: Tuple of variables representing initial population sizes.
+        """
+        assert isinstance(self.model, TreeDemographicModel)
+        leaves = self._leaves()
+        init_pop_sizes = []
+        for leaf in leaves:
+            init_pop_sizes.append(leaf.size_pop.name)
+        return tuple(init_pop_sizes)
+
+    def _g_to_complex_param(self, g: Division, dyn: DynamicVariable) -> str:
+        """
+        Convert growth rate variable to fsc2-style complex parameter.
+
+        :param g: VariablesCombination that determines the growth rate formula.
+        :param dyn: Population dynamic variable.
+        :return: fsc2-style complex parameter name.
+        """
+        n_t = g.variables[0].name
+        n_0 = g.variables[1].name
+        n_div = f'{n_t}_{n_0}div$'
+        n_div_complex_param = f'{n_t}$/{n_0}$'
+        self._update_fsc2_complex_params(n_div, n_div_complex_param)
+        if isinstance(g.variables[2], Addition):
+            t = self._time_to_complex_param(g.variables[2])
+        else:
+            t = g.variables[2].name + '$'
+        name = dyn.name + '$'
+        complex_param = f'log({n_div})/{t}'
+        self._update_fsc2_complex_params(name, complex_param)
+        return name
+
+    def _time_to_complex_param(self, time_var: Addition) -> str:
+        """
+        Converts time variable to fsc2-style complex parameter.
+
+        :param time_var: Time variable.
+        :return: fsc2-style complex parameter name.
+        """
+        var_names = [v.name for v in time_var.variables]
+        name = '_'.join(var_names) + 'sum$'
+        complex_param = ' + '.join([f'{n}$' for n in var_names])
+        self._update_fsc2_complex_params(name, complex_param)
+        return name
+
+    def _update_fsc2_complex_params(self, name: str, complex_param: str) -> NoReturn:
+        complex_params = self._fsc2_complex_parameters
+        if name not in complex_params:
+            complex_params.update({name: complex_param})
+
+    def _generate_estimation_file(self, values: ParameterValues) -> EstimationFile:
+        file = EstimationFile()
+
+        params: List[Dict] = self._variables_to_fsc2_est_params(values)
+        file.write_parameters(params)
+
+        compl_params = self._complex_parameters()
+        file.write_complex_parameters(compl_params)
+        return file
+
+    def _variables_to_fsc2_est_params(self, values: ParameterValues) -> List[Dict]:
+        variables = self.model.variables
+        est_params = []
+        for variable in variables:
+            if isinstance(variable, DynamicVariable):
+                continue
+            param = {'is_int': 1,
+                     'name': variable.name + '$',
+                     'dist': 'unif',
+                     'minimum': variable.domain[0],
+                     'maximum': variable.domain[1],
+                     'output': True,
+                     'bounded': True}
+            var_value = self.get_value_from_var2value(values, variable)
+            if isinstance(var_value, float):
+                param['is_int'] = 0
+            est_params.append(param)
+        return est_params
+
+    def _complex_parameters(self) -> List[Dict[str, Union[int, str]]]:
+        compl_params = []
+        fsc2_compl_params = self._fsc2_complex_parameters
+        for name, value in fsc2_compl_params.items():
+            param = {'is_int': 1,
+                     'name': name,
+                     'definition': value,
+                     'output': False}
+            if 'dyn' in name or '/' in value:
+                param['is_int'] = 0
+            if not param['name'].endswith('$'):
+                param['name'] += '$'
+            compl_params.append(param)
+        return compl_params
+
+    def _generate_definitions_file(self, values: ParameterValues) -> DefinitionFile:
+        names = tuple(var.name for var in self.model.variables
+                      if not isinstance(var, DynamicVariable))
+        vals = [values[var] for var in self.model.variables
+                if not isinstance(var, DynamicVariable)]
+        file = DefinitionFile(names, vals)
+        return file
+
+    @staticmethod
+    def _find_max_obs_lhood(workdir, prefix) -> float:
+        best_lhood_fpath = Path(workdir, prefix, f'{prefix}.bestlhoods')
+        best_lhood_data = np.loadtxt(best_lhood_fpath, delimiter='\t', skiprows=1)
+        max_obs_lhood = best_lhood_data[-1]
+        assert isinstance(max_obs_lhood, float)
+        return max_obs_lhood
+
+    def _new_sfs_name(self, sfs_name: str, prefix: str) -> str:
+        pattern = re.compile(r'(.*)((?:_DAFpop0|_jointDAFpop1_0)\.obs)')
+        match = re.search(pattern, sfs_name)
+        if match:
+            new_name = f'{prefix}{match.group(2)}'
+        pattern = re.compile(r'(.*)((?:DAFpop0|jointDAFpop1_0)\.obs)')
+        match = re.search(pattern, sfs_name)
+        new_name = f'{prefix}_{match.group(2)}'
+        return new_name
+
+
+fsc2_available = True  # TODO: check for fsc2 availability
+# fsc2_available = Path(FSC2_PATH).exists()
+
+if fsc2_available:
+    register_engine(FastSimCoal2Engine)

--- a/gadma/engines/fsc2_engine.py
+++ b/gadma/engines/fsc2_engine.py
@@ -519,17 +519,27 @@ class FastSimCoal2Engine(Engine):
         """
         n_t = g.variables[0].name
         n_0 = g.variables[1].name
-        n_div = f'{n_t}_{n_0}div$'
-        n_div_complex_param = f'{n_t}$/{n_0}$'
-        self._update_fsc2_complex_params(n_div, n_div_complex_param)
-        if isinstance(g.variables[2], Addition):
-            t = self._time_to_complex_param(g.variables[2])
+        n_div_name = f'{n_t}_{n_0}div$'
+        n_div_parameter = f'{n_t}$/{n_0}$'
+
+        complex_parameters = self._fsc2_complex_parameters
+        if n_div_name not in complex_parameters:
+            complex_parameters.update({n_div_name: n_div_parameter})
+        self._fsc2_complex_parameters = complex_parameters
+
+        time = g.variables[2]
+        if isinstance(time, Addition):
+            time_name = self._time_to_complex_param(time)
         else:
-            t = g.variables[2].name + '$'
-        name = dyn.name + '$'
-        complex_param = f'log({n_div})/{t}'
-        self._update_fsc2_complex_params(name, complex_param)
-        return name
+            time_name = time.name + '$'
+
+        dyn_name = dyn.name + '$'
+        dyn_parameter = f'log({n_div_name})/{time_name}'
+
+        if dyn_name not in complex_parameters:
+            complex_parameters.update({dyn_name: dyn_parameter})
+        self._fsc2_complex_parameters = complex_parameters
+        return dyn_name
 
     def _time_to_complex_param(self, time_var: Addition) -> str:
         """

--- a/gadma/engines/fsc2_engine.py
+++ b/gadma/engines/fsc2_engine.py
@@ -6,7 +6,8 @@ import tempfile
 from io import StringIO
 from math import log
 from pathlib import Path
-from typing import Final, Union, List, Dict, NoReturn, Tuple, Callable, Optional, ClassVar, NamedTuple
+from typing import Final, Union, List, Dict, NoReturn, Tuple, Callable, Optional, ClassVar, NamedTuple, Sequence, \
+    Mapping
 
 import numpy as np
 from dadi import Spectrum
@@ -498,7 +499,7 @@ class FastSimCoal2Engine(Engine):
 
     @staticmethod
     def run_fsc2(fsc2_path: str,
-                 args: List[str],
+                 args: Sequence[str],
                  workdir: Union[str, os.PathLike]) -> NoReturn:
         """
         Run fastsimcoal2 with specified arguments.
@@ -613,7 +614,7 @@ class FastSimCoal2Engine(Engine):
             est_params.append(param)
         return est_params
 
-    def _complex_parameters(self) -> List[Dict[str, Union[int, str]]]:
+    def _complex_parameters(self) -> Sequence[Mapping[str, Union[int, str]]]:
         complex_params = []
         fsc2_complex_params = self._fsc2_complex_parameters
         for name, value in fsc2_complex_params.items():

--- a/gadma/engines/fsc2_engine.py
+++ b/gadma/engines/fsc2_engine.py
@@ -9,7 +9,7 @@ from contextlib import redirect_stdout
 from io import StringIO
 from math import log
 from pathlib import Path
-from typing import Final, Union, List, Dict, NoReturn, Tuple, Callable, Optional, ClassVar
+from typing import Final, Union, List, Dict, NoReturn, Tuple, Callable, Optional, ClassVar, NamedTuple
 
 import numpy as np
 from numpy import ndarray
@@ -44,6 +44,12 @@ def is_msfs(data_holder: SFSDataHolder):
         return True
     else:
         return False
+
+
+class FastSimCoal2InputFiles(NamedTuple):
+    template_file: str
+    estimation_file: str
+    definition_file: str
 
 
 class FastSimCoal2Engine(Engine):
@@ -83,7 +89,7 @@ class FastSimCoal2Engine(Engine):
         self.set_model(fsc2_model)
 
         if isinstance(self.model, CustomDemographicModel):
-            assert (isinstance(self.model.function, tuple)
+            assert (isinstance(self.model.function, FastSimCoal2InputFiles)
                     and all(isinstance(elem, (str, os.PathLike)) for elem in self.model.function))
             tpl_file, est_file, def_file = self.model.function
 

--- a/gadma/engines/fsc2_engine.py
+++ b/gadma/engines/fsc2_engine.py
@@ -44,6 +44,219 @@ def is_msfs(data_holder: SFSDataHolder):
         return False
 
 
+def _find_matching_event(tree_event: TreeModelEvent,
+                         epoch_events: List[EpochModelEvent]) -> Optional[EpochModelEvent]:
+    """
+    Find all events in an ``EpochDemographicModel``
+    that match to the event from a ``TreeDemographicModel``
+
+    :param tree_event: A ``TreeDemographicModel`` event that is used for comparison
+    :param epoch_events: A list of ``EpochDemographicModel`` events that should be
+        searched for matching events
+    """
+    # TODO: Make a fix for this edge case.
+    #  TreeDemographicModel doesn't have an event for migration matrix switch.
+    #  Therefore, this algorithm will not find a matching Epoch/Split,
+    #  if there's an Epoch that has migration matrix switch as its only change
+    #  compared to the Epoch after it.
+    #  Which means that this change will not be recorded in the estimation file.
+    time: TimeVariable = tree_event.t.variables[-1]
+
+    def next_epoch_time(split: Split) -> Union[TimeVariable, int]:
+        event_index = epoch_events.index(split)
+        try:
+            event_after_index = event_index + 1
+            if not isinstance(epoch_events[event_after_index], Epoch):
+                event_after_index += 1
+        except IndexError:
+            return 0
+        else:
+            return epoch_events[event_after_index].time_arg
+
+    def pop_size_change_condition(epoch: Epoch) -> bool:
+        return (isinstance(tree_event, PopulationSizeChange)
+                and isinstance(epoch, Epoch)
+                and epoch.time_arg == time)
+
+    def lineage_movement_condition(split: Split) -> bool:
+        return (isinstance(tree_event, LineageMovement)
+                and isinstance(split, Split)
+                and next_epoch_time(split) == time
+                and split.pop_to_div == tree_event.pop_from)
+
+    if isinstance(tree_event, Leaf):
+        return None
+    for event in epoch_events:
+        if (pop_size_change_condition(event)
+                or lineage_movement_condition(event)):
+            return event
+
+
+def _map_model_events(model_tree_events: List[TreeModelEvent],
+                      model_epoch_events: List[EpochModelEvent]) -> Dict[TreeModelEvent,
+                                                                         EpochModelEvent]:
+    """
+    Map events of an ``TreeDemographicModel`` model
+    to its ``EpochDemographicModel`` counterpart
+
+    :param model_tree_events: Its tree-based counterpart events
+    :param model_epoch_events: Epoch-based demographic model events
+
+    :return: Dictionary with ``PopulationSizeChange`` and ``LineageMovement`` events
+        mapped to ``Epoch`` and ``Split`` events, accordingly.
+    """
+    event_mapping = {}
+    for tree_event in model_tree_events:
+        if isinstance(tree_event, Leaf):
+            continue
+        matching_event = _find_matching_event(tree_event, model_epoch_events)
+        event_mapping[tree_event] = matching_event
+    return event_mapping
+
+
+def _get_fsc2_model(model, values: ParameterValues) -> Tuple[Model, ParameterValues]:
+    from gadma import DemographicModel
+    assert isinstance(model, DemographicModel)
+    fsc2_model = model
+    if isinstance(model, EpochDemographicModel):
+        fsc2_model, values = model.translate_to(TreeDemographicModel, values)
+    return fsc2_model, values
+
+
+def _get_initial_pop_sizes(model: TreeDemographicModel) -> Tuple:
+    """
+    Get population sizes at current time.
+    :returns: Tuple of variables representing initial population sizes.
+    """
+    assert isinstance(model, TreeDemographicModel)
+    leaves = _leaves(model)
+    init_pop_sizes = []
+    for leaf in leaves:
+        init_pop_sizes.append(leaf.size_pop.name)
+    return tuple(init_pop_sizes)
+
+
+def _get_growth_rate_for_population(model, values: ParameterValues,
+                                    pop: int,
+                                    epoch: Epoch) -> float:
+    # TODO: Rewrite with TreeModelEvent in mind
+    growth_rates = _get_growth_rate(model, values, epoch)
+    return growth_rates[pop]
+
+
+def _get_growth_rate(model, values: ParameterValues,
+                     event: TreeModelEvent) -> float:
+    # TODO: Rewrite with TreeModelEvent in mind
+    var2value: Callable = model.get_value_from_var2value
+
+    init_pop_sizes_vars: List[PopulationSizeVariable] = event.init_size_args
+    final_pop_sizes_vars: List[PopulationSizeVariable] = event.size_args
+    time_var: TimeVariable = event.time_arg
+
+    init_pop_sizes: Tuple = tuple(var2value(values, v) for v in init_pop_sizes_vars)
+    final_pop_sizes: Tuple = tuple(var2value(values, v) for v in final_pop_sizes_vars)
+    time: int = var2value(values, time_var)
+
+    growth_rates = []
+    for size_0, size_t in zip(final_pop_sizes, init_pop_sizes):
+        # Growth is exponential: N_t=N_0e^{rt}, where `r` is the growth rate.
+        # Therefore, r=\frac{\ln \left(\frac{N_t}{N_0}\right)}{t}
+        growth_rate = (log(size_t / size_0)) / time
+        growth_rates.append(growth_rate)
+    return growth_rates
+
+
+def _get_zero_matrix(model: TreeDemographicModel) -> ndarray:
+    leaf_count = len([e for e in model.events if isinstance(e, Leaf)])
+    zero_matrix = np.zeros([leaf_count, leaf_count], dtype=int)
+    return zero_matrix
+
+
+def _get_migration_matrices(model, values: ParameterValues) -> Tuple[ndarray, ...]:
+    """
+    Gathers all migration matrices in the model in a single tuple.
+    Also adds a zero matrix at the end of the tuple.
+    :param values: Model parameter values
+    :return: Migration matrices.
+    """
+    # TODO: Write code for resizing all matrices to one size according to the population count
+    matrices = []
+    for event in model.events:
+        if isinstance(event, Epoch):
+            matrix: ndarray = event.mig_args.copy()
+            if matrix is None:
+                continue
+            matrix = model.get_value_from_var2value(values, matrix)
+            matrices.append(matrix)
+    matrices += _get_zero_matrix(model)
+    return tuple(matrices)
+
+
+def _first_event(model: TreeDemographicModel):
+    non_leaf_events = [e for e in model.events if not isinstance(e, Leaf)]
+    first_event = non_leaf_events[0]
+    return first_event
+
+
+def _leaves(model: TreeDemographicModel) -> List[Leaf]:
+    leaves = []
+    for event in model.events:
+        if isinstance(event, Leaf):
+            leaves.append(event)
+    leaves.sort(key=lambda leaf: leaf.pop)
+    return leaves
+
+
+def _find_max_obs_lhood(workdir, prefix) -> float:
+    best_lhood_fpath = Path(workdir, prefix, f'{prefix}.bestlhoods')
+    best_lhood_data = np.loadtxt(best_lhood_fpath, delimiter='\t', skiprows=1)
+    max_obs_lhood = best_lhood_data[-1]
+    assert isinstance(max_obs_lhood, float)
+    return max_obs_lhood
+
+
+def _new_sfs_name(sfs_file_name: str, base_name: str) -> str:
+    """
+    Replaces the base name (or adds one if absent) of an fsc2 SFS file.
+
+    Accepted input file name formats:
+
+    * ``*DAFpop0.obs``, ``*_DAFpop0.obs``
+    * ``*jointDAFpop1_0.obs``, ``*_jointDAFpop1_0.obs``
+    * ``*DSFS.obs``, ``*_DSFS.obs``
+
+    :param sfs_file_name: Name of the file to be renamed. For expected formats see the list.
+    :param base_name: New base name of the file (usually something like "gadma_fsc2")
+
+    :return: New file name.
+
+    :raise ValueError: if *sfs_file_name* doesn't conform to expected file name formats.
+    """
+    pattern_ = re.compile(r'(.*)(_(?:DAFpop0|jointDAFpop1_0|DSFS)\.obs)')
+    pattern = re.compile(r'(.*)((?:DAFpop0|jointDAFpop1_0|DSFS)\.obs)')
+    match_ = re.search(pattern_, sfs_file_name)
+    match = re.search(pattern, sfs_file_name)
+    if match is not None:
+        # '*jointDAFpop1_0.obs' -> '{base_name}_jointDAFpop1_0.obs
+        suffix = match.group(2)
+        new_name = f'{base_name}_{suffix}'
+    elif match_ is not None:
+        # '*_jointDAFpop1_0.obs' -> '{base_name}_jointDAFpop1_0.obs
+        suffix = match_.group(2)
+        new_name = f'{base_name}{suffix}'
+    else:
+        raise ValueError(f"File name {sfs_file_name} does not conform to expected format")
+    return new_name
+
+
+def _infer_sample_sizes(sfs_data) -> Tuple[int, ...]:
+    """
+    Infer sample sizes from the observed SFS file.
+    :return: Sample sizes.
+    """
+    return tuple(sfs_data.sample_sizes.tolist())
+
+
 class FastSimCoal2InputFiles(NamedTuple):
     template_file: str
     estimation_file: str
@@ -88,7 +301,7 @@ class FastSimCoal2Engine(Engine):
 
         with tempfile.TemporaryDirectory(prefix=f'{self.PREFIX}_') as workdir:
             sfs_name = Path(self.data).name
-            new_sfs_name = self._new_sfs_name(sfs_name, self.PREFIX)
+            new_sfs_name = _new_sfs_name(sfs_name, self.PREFIX)
             print(f'{sfs_name} -> {new_sfs_name}', end=LINE)
             new_sfs_path = Path(workdir, new_sfs_name)
             shutil.copy(self.data, new_sfs_path)
@@ -122,7 +335,7 @@ class FastSimCoal2Engine(Engine):
             self.run_fsc2(FSC2_PATH, args, workdir=workdir, stdout=fsc2_stdout)
             print('-' * 80)
 
-            likelihood = self._find_max_obs_lhood(workdir, self.PREFIX)
+            likelihood = _find_max_obs_lhood(workdir, self.PREFIX)
         return likelihood
 
     def _process_values(self, values: ParameterValues) -> Dict:
@@ -181,19 +394,19 @@ class FastSimCoal2Engine(Engine):
     def _generate_template_file(self):
         file = TemplateFile()
 
-        current_n_of_pops: int = self._infer_n_of_populations()
+        current_n_of_pops: int = self.sfs_data.Npop
         file.write_number_of_population_samples(current_n_of_pops)
 
-        current_pop_sizes: Tuple = self._get_initial_pop_sizes()
+        current_pop_sizes: Tuple = _get_initial_pop_sizes(self.model)
         file.write_initial_effective_population_sizes(current_pop_sizes)
 
-        sample_sizes: Tuple[int, ...] = self._infer_sample_sizes()
+        sample_sizes: Tuple[int, ...] = _infer_sample_sizes(self.sfs_data)
         file.write_sample_sizes(sample_sizes)
 
         initial_growth_rates: Tuple[Union[int, str]] = self._get_initial_growth_rates()
         file.write_initial_growth_rates(initial_growth_rates)
 
-        matrices: Tuple[ndarray, ...] = tuple([self._zero_matrix])
+        matrices: Tuple[ndarray, ...] = tuple([_get_zero_matrix(self.model)])
         file.write_migration_matrices(matrices)
 
         events: Tuple[dict, ...] = self._get_events()
@@ -205,22 +418,6 @@ class FastSimCoal2Engine(Engine):
                                     recombination_rate=0, mutation_rate=2.5e-8)
         return file
 
-    def _infer_n_of_populations(self) -> int:
-        """
-        Infer number of populations from the name of the observed SFS file.
-        See fastsimcoal2 manual, Observed SFS file names
-
-        :return: Number of populations.
-        """
-        return self.sfs_data.Npop
-
-    def _infer_sample_sizes(self) -> Tuple[int, ...]:
-        """
-        Infer sample sizes from the observed SFS file.
-        :return: Sample sizes.
-        """
-        return tuple(self.sfs_data.sample_sizes.tolist())
-
     @property
     def sfs_data(self):
         from gadma.engines.dadi_moments_common import read_sfs_data
@@ -231,7 +428,7 @@ class FastSimCoal2Engine(Engine):
         return sfs
 
     def _get_initial_growth_rates(self) -> Tuple[Union[int, str], ...]:
-        leaves = self._leaves()
+        leaves = _leaves(self.model)
         growth_rates = []
         for leaf in leaves:
             if leaf.g == 0:
@@ -240,48 +437,6 @@ class FastSimCoal2Engine(Engine):
                 growth_rate = self._g_to_complex_param(leaf.g, leaf.dyn)
             growth_rates.append(growth_rate)
         return tuple(growth_rates)
-
-    def _leaves(self):
-        leaves = []
-        for event in self.model.events:
-            if isinstance(event, Leaf):
-                leaves.append(event)
-        leaves.sort(key=lambda leaf: leaf.pop)
-        return leaves
-
-    # Unused
-    @property
-    def _first_event(self):
-        if self.model is None:
-            raise RuntimeError(f"Attribute `model` of engine {self.id} has not been set.")
-        non_leaf_events = [e for e in self.model.events if not isinstance(e, Leaf)]
-        first_event = self.model.non_leaf_events[0]
-        return first_event
-
-    def _get_migration_matrices(self, values: ParameterValues) -> Tuple[ndarray, ...]:
-        """
-        Gathers all migration matrices in the model in a single tuple.
-        Also adds a zero matrix at the end of the tuple.
-        :param values: Model parameter values
-        :return: Migration matrices.
-        """
-        # TODO: Write code for resizing all matrices to one size according to the population count
-        matrices = []
-        for event in self.model.events:
-            if isinstance(event, Epoch):
-                matrix: ndarray = event.mig_args.copy()
-                if matrix is None:
-                    continue
-                matrix = self.model.get_value_from_var2value(values, matrix)
-                matrices.append(matrix)
-        matrices += self._zero_matrix
-        return tuple(matrices)
-
-    @property
-    def _zero_matrix(self) -> ndarray:
-        leaf_count = len([e for e in self.model.events if isinstance(e, Leaf)])
-        zero_matrix = np.zeros([leaf_count, leaf_count], dtype=int)
-        return zero_matrix
 
     def _get_events(self) -> Tuple[Dict[str, Union[str, int]], ...]:
         model_events: list = self.model.events
@@ -327,78 +482,6 @@ class FastSimCoal2Engine(Engine):
             fsc2_events.append(fsc2_event)
         return tuple(fsc2_events)
 
-    # Unused
-    def _map_model_events(self,
-                          model_tree_events: List[TreeModelEvent],
-                          model_epoch_events: List[EpochModelEvent]) -> Dict[TreeModelEvent,
-                                                                             EpochModelEvent]:
-        """
-        Map events of an ``TreeDemographicModel`` model
-        to its ``EpochDemographicModel`` counterpart
-
-        :param model_tree_events: Its tree-based counterpart events
-        :param model_epoch_events: Epoch-based demographic model events
-
-        :return: Dictionary with ``PopulationSizeChange`` and ``LineageMovement`` events
-            mapped to ``Epoch`` and ``Split`` events, accordingly.
-        """
-        event_mapping = {}
-        for tree_event in model_tree_events:
-            if isinstance(tree_event, Leaf):
-                continue
-            matching_event = self._find_matching_event(tree_event, model_epoch_events)
-            event_mapping[tree_event] = matching_event
-        return event_mapping
-
-    # Used in FastSimCoal2Engine._map_model_events, therefore unused in general
-    @staticmethod
-    def _find_matching_event(tree_event: TreeModelEvent,
-                             epoch_events: List[EpochModelEvent]) -> Optional[EpochModelEvent]:
-        """
-        Find all events in an ``EpochDemographicModel``
-        that match to the event from a ``TreeDemographicModel``
-
-        :param tree_event: A ``TreeDemographicModel`` event that is used for comparison
-        :param epoch_events: A list of ``EpochDemographicModel`` events that should be
-            searched for matching events
-        """
-        # TODO: Make a fix for this edge case.
-        #  TreeDemographicModel doesn't have an event for migration matrix switch.
-        #  Therefore, this algorithm will not find a matching Epoch/Split,
-        #  if there's an Epoch that has migration matrix switch as its only change
-        #  compared to the Epoch after it.
-        #  Which means that this change will not be recorded in the estimation file.
-        time: TimeVariable = tree_event.t.variables[-1]
-
-        def next_epoch_time(split: Split) -> Union[TimeVariable, int]:
-            event_index = epoch_events.index(split)
-            try:
-                event_after_index = event_index + 1
-                if not isinstance(epoch_events[event_after_index], Epoch):
-                    event_after_index += 1
-            except IndexError:
-                return 0
-            else:
-                return epoch_events[event_after_index].time_arg
-
-        def pop_size_change_condition(epoch: Epoch) -> bool:
-            return (isinstance(tree_event, PopulationSizeChange)
-                    and isinstance(epoch, Epoch)
-                    and epoch.time_arg == time)
-
-        def lineage_movement_condition(split: Split) -> bool:
-            return (isinstance(tree_event, LineageMovement)
-                    and isinstance(split, Split)
-                    and next_epoch_time(split) == time
-                    and split.pop_to_div == tree_event.pop_from)
-
-        if isinstance(tree_event, Leaf):
-            return None
-        for event in epoch_events:
-            if (pop_size_change_condition(event)
-                    or lineage_movement_condition(event)):
-                return event
-
     @staticmethod
     def run_fsc2(fsc2_path: str,
                  args: List[str],
@@ -422,66 +505,13 @@ class FastSimCoal2Engine(Engine):
         #     retcode = subprocess.call([fsc2_path, args], shell=True, cwd=workdir)
 
     def update_data_holder_with_inner_data(self):
-        # TODO: Code for processing inner data goes here
-        self.data_holder.projections = self._infer_sample_sizes()
+        self.data_holder.projections = _infer_sample_sizes(self.sfs_data)
         self.data_holder.population_labels = None
         self.data_holder.outgroup = None
 
     @classmethod
     def _read_data(cls, data_holder: SFSDataHolder) -> inner_data_type:
         return data_holder.filename
-
-    # Unused
-    def _get_growth_rate_for_population(self,
-                                        values: ParameterValues,
-                                        pop: int,
-                                        epoch: Epoch) -> float:
-        # TODO: Rewrite with TreeModelEvent in mind
-        growth_rates = self._get_growth_rate(values, epoch)
-        return growth_rates[pop]
-
-    # Used in FastSimCoal2Engine._get_growth_rate_for_population, so unused in general
-    def _get_growth_rate(self,
-                         values: ParameterValues,
-                         event: TreeModelEvent) -> float:
-        # TODO: Rewrite with TreeModelEvent in mind
-        var2value: Callable = self.model.get_value_from_var2value
-
-        init_pop_sizes_vars: List[PopulationSizeVariable] = event.init_size_args
-        final_pop_sizes_vars: List[PopulationSizeVariable] = event.size_args
-        time_var: TimeVariable = event.time_arg
-
-        init_pop_sizes: Tuple = tuple(var2value(values, v) for v in init_pop_sizes_vars)
-        final_pop_sizes: Tuple = tuple(var2value(values, v) for v in final_pop_sizes_vars)
-        time: int = var2value(values, time_var)
-
-        growth_rates = []
-        for size_0, size_t in zip(final_pop_sizes, init_pop_sizes):
-            # Growth is exponential: N_t=N_0e^{rt}, where `r` is the growth rate.
-            # Therefore, r=\frac{\ln \left(\frac{N_t}{N_0}\right)}{t}
-            growth_rate = (log(size_t / size_0)) / time
-            growth_rates.append(growth_rate)
-        return growth_rates
-
-    def _get_fsc2_model(self, values: ParameterValues) -> Tuple[Union[CustomDemographicModel,
-                                                                      TreeDemographicModel],
-                                                                ParameterValues]:
-        model = self.model
-        if isinstance(self.model, EpochDemographicModel):
-            model, values = self.model.translate_to(TreeDemographicModel, values)
-        return model, values
-
-    def _get_initial_pop_sizes(self) -> Tuple:
-        """
-        Get population sizes at current time.
-        :returns: Tuple of variables representing initial population sizes.
-        """
-        assert isinstance(self.model, TreeDemographicModel)
-        leaves = self._leaves()
-        init_pop_sizes = []
-        for leaf in leaves:
-            init_pop_sizes.append(leaf.size_pop.name)
-        return tuple(init_pop_sizes)
 
     def _g_to_complex_param(self, g: Division, dyn: DynamicVariable) -> str:
         """
@@ -514,14 +544,12 @@ class FastSimCoal2Engine(Engine):
         """
         var_names = [v.name for v in time_var.variables]
         name = '_'.join(var_names) + 'sum$'
-        complex_param = ' + '.join([f'{n}$' for n in var_names])
-        self._update_fsc2_complex_params(name, complex_param)
+        parameter = ' + '.join([f'{n}$' for n in var_names])
+        complex_parameters = self._fsc2_complex_parameters
+        if name not in complex_parameters:
+            complex_parameters.update({name: parameter})
+        self._fsc2_complex_parameters = complex_parameters
         return name
-
-    def _update_fsc2_complex_params(self, name: str, complex_param: str) -> NoReturn:
-        complex_params = self._fsc2_complex_parameters
-        if name not in complex_params:
-            complex_params.update({name: complex_param})
 
     def _generate_estimation_file(self, values: ParameterValues) -> EstimationFile:
         file = EstimationFile()
@@ -574,48 +602,6 @@ class FastSimCoal2Engine(Engine):
                 if not isinstance(var, DynamicVariable)]
         file = DefinitionFile(names, vals)
         return file
-
-    @staticmethod
-    def _find_max_obs_lhood(workdir, prefix) -> float:
-        best_lhood_fpath = Path(workdir, prefix, f'{prefix}.bestlhoods')
-        best_lhood_data = np.loadtxt(best_lhood_fpath, delimiter='\t', skiprows=1)
-        max_obs_lhood = best_lhood_data[-1]
-        assert isinstance(max_obs_lhood, float)
-        return max_obs_lhood
-
-    @staticmethod
-    def _new_sfs_name(sfs_file_name: str, base_name: str) -> str:
-        """
-        Replaces the base name (or adds one if absent) of an fsc2 SFS file.
-
-        Accepted input file name formats:
-
-        * ``*DAFpop0.obs``, ``*_DAFpop0.obs``
-        * ``*jointDAFpop1_0.obs``, ``*_jointDAFpop1_0.obs``
-        * ``*DSFS.obs``, ``*_DSFS.obs``
-
-        :param sfs_file_name: Name of the file to be renamed. For expected formats see the list.
-        :param base_name: New base name of the file (usually something like "gadma_fsc2")
-
-        :return: New file name.
-
-        :raise ValueError: if *sfs_file_name* doesn't conform to expected file name formats.
-        """
-        pattern_ = re.compile(r'(.*)(_(?:DAFpop0|jointDAFpop1_0|DSFS)\.obs)')
-        pattern = re.compile(r'(.*)((?:DAFpop0|jointDAFpop1_0|DSFS)\.obs)')
-        match_ = re.search(pattern_, sfs_file_name)
-        match = re.search(pattern, sfs_file_name)
-        if match is not None:
-            # '*jointDAFpop1_0.obs' -> '{base_name}_jointDAFpop1_0.obs
-            suffix = match.group(2)
-            new_name = f'{base_name}_{suffix}'
-        elif match_ is not None:
-            # '*_jointDAFpop1_0.obs' -> '{base_name}_jointDAFpop1_0.obs
-            suffix = match_.group(2)
-            new_name = f'{base_name}{suffix}'
-        else:
-            raise ValueError(f"File name {sfs_file_name} does not conform to expected format")
-        return new_name
 
 
 if Path(FSC2_PATH).exists():

--- a/gadma/engines/fsc2_engine.py
+++ b/gadma/engines/fsc2_engine.py
@@ -2,10 +2,7 @@ import io
 import os
 import re
 import shutil
-import subprocess
-import sys
 import tempfile
-from contextlib import redirect_stdout
 from io import StringIO
 from math import log
 from pathlib import Path
@@ -15,14 +12,13 @@ import numpy as np
 from numpy import ndarray
 
 from . import Engine, register_engine
-from ..models import EpochDemographicModel, TreeDemographicModel, Epoch, Split, \
-    PopulationSizeChange, Leaf, LineageMovement
-
-from ..utils.variables import PopulationSizeVariable, TimeVariable, DynamicVariable
-from ..data import SFSDataHolder
-from ..models import CustomDemographicModel
-from ..models.variables_combinations import Addition, Division
 from ..code_generator.fsc2_generator import EstimationFile, TemplateFile, DefinitionFile
+from ..data import SFSDataHolder
+from ..models import CustomDemographicModel, EpochDemographicModel, TreeDemographicModel, Epoch, \
+    Split, \
+    PopulationSizeChange, Leaf, LineageMovement
+from ..models.variables_combinations import Addition, Division
+from ..utils.variables import PopulationSizeVariable, TimeVariable, DynamicVariable
 
 LINE = ("\n" + "-" * 80 + "\n")
 

--- a/gadma/engines/fsc2_engine.py
+++ b/gadma/engines/fsc2_engine.py
@@ -93,7 +93,7 @@ class FastSimCoal2Engine(Engine):
                     and all(isinstance(elem, (str, os.PathLike)) for elem in self.model.function))
             tpl_file, est_file, def_file = self.model.function
 
-        with tempfile.TemporaryDirectory(prefix=self.PREFIX) as workdir:
+        with tempfile.TemporaryDirectory(prefix=f'{self.PREFIX}_') as workdir:
             sfs_name = Path(self.data).name
             new_sfs_name = self._new_sfs_name(sfs_name, self.PREFIX)
             shutil.copy(self.data, Path(workdir, new_sfs_name))

--- a/gadma/engines/fsc2_engine.py
+++ b/gadma/engines/fsc2_engine.py
@@ -587,9 +587,9 @@ class FastSimCoal2Engine(Engine):
         return est_params
 
     def _complex_parameters(self) -> List[Dict[str, Union[int, str]]]:
-        compl_params = []
-        fsc2_compl_params = self._fsc2_complex_parameters
-        for name, value in fsc2_compl_params.items():
+        complex_params = []
+        fsc2_complex_params = self._fsc2_complex_parameters
+        for name, value in fsc2_complex_params.items():
             param = {'is_int': 1,
                      'name': name,
                      'definition': value,
@@ -598,8 +598,8 @@ class FastSimCoal2Engine(Engine):
                 param['is_int'] = 0
             if not param['name'].endswith('$'):
                 param['name'] += '$'
-            compl_params.append(param)
-        return compl_params
+            complex_params.append(param)
+        return complex_params
 
     def _generate_definitions_file(self, values: ParameterValues) -> DefinitionFile:
         names = tuple(var.name for var in self.model.variables

--- a/gadma/engines/fsc2_engine.py
+++ b/gadma/engines/fsc2_engine.py
@@ -417,9 +417,10 @@ class FastSimCoal2Engine(Engine):
         assert Path(fsc2_path).exists(), "Can't find fsc2 binary"
         args: str = " ".join([str(e) for e in args])
         command = f"cd {cwd}; {fsc2_path} {args}"
-        # os.system(command)
-        with redirect_stdout(stdout):
-            retcode = subprocess.call([fsc2_path, args], shell=True, cwd=cwd)
+        print(command)
+        os.system(command)
+        # with redirect_stdout(stdout):
+        #     retcode = subprocess.call([fsc2_path, args], shell=True, cwd=cwd)
 
     def update_data_holder_with_inner_data(self):
         # TODO: Code for processing inner data goes here

--- a/gadma/engines/fsc2_engine.py
+++ b/gadma/engines/fsc2_engine.py
@@ -38,6 +38,14 @@ def fsc2_available() -> bool:
     return True
 
 
+def is_msfs(data_holder: SFSDataHolder):
+    filename = Path(data_holder.filename).name
+    if 'DSFS' in filename or 'MSFS' in filename:
+        return True
+    else:
+        return False
+
+
 class FastSimCoal2Engine(Engine):
     """Class representing the fastsimcoal2 engine"""
     id: Final[str] = 'fsc2'
@@ -97,6 +105,9 @@ class FastSimCoal2Engine(Engine):
                     '-M',                 # estimation by composite max likelihood
                     '-n', n_simulations,  # number of simulations
                     '-L', n_loops]        # number of ECM cycles
+
+            if is_msfs(self.data_holder):
+                args.append('--multiSFS')
 
             fsc2_stdout: StringIO = io.StringIO()
 

--- a/gadma/engines/fsc2_engine.py
+++ b/gadma/engines/fsc2_engine.py
@@ -36,7 +36,7 @@ def fsc2_available() -> bool:
     return True
 
 
-def is_msfs(data_holder: SFSDataHolder):
+def is_multi_sfs(data_holder: SFSDataHolder):
     filename = Path(data_holder.filename).name
     if 'DSFS' in filename or 'MSFS' in filename:
         return True
@@ -326,7 +326,7 @@ class FastSimCoal2Engine(Engine):
                     '-n', n_simulations,  # number of simulations
                     '-L', n_loops]  # number of ECM cycles
 
-            if is_msfs(self.data_holder):
+            if is_multi_sfs(self.data_holder):
                 args.append('--multiSFS')
 
             print([f.name for f in Path(workdir).iterdir()])

--- a/gadma/engines/fsc2_engine.py
+++ b/gadma/engines/fsc2_engine.py
@@ -491,12 +491,13 @@ class FastSimCoal2Engine(Engine):
         :param args: Arguments to pass to fastsimcoal2.
         :param workdir: Working directory for calculations.
         """
-        # TODO: Come up with a way to use the `subprocess` library
         assert Path(fsc2_path).exists(), "Can't find fsc2 binary"
         args: str = " ".join([str(e) for e in args])
         command = f"cd {workdir}; {fsc2_path} {args}"
         print(command)
         os.system(command)
+        # TODO: Come up with a way to use the `subprocess` library
+        # stdout = io.StringIO()
         # with redirect_stdout(stdout):
         #     retcode = subprocess.call([fsc2_path, args], shell=True, cwd=workdir)
 

--- a/gadma/models/custom_demographic_model.py
+++ b/gadma/models/custom_demographic_model.py
@@ -22,6 +22,8 @@ class CustomDemographicModel(DemographicModel):
                  gen_time=None, theta0=None,
                  mutation_rate=None, recombination_rate=None,
                  fixed_anc_size=None, has_anc_size=False):
+        # TODO: @EkaterinaNoskova: `self.filepath` might be a better name, since FastSimCoal2Engine uses
+        #  native fastsimcoal2 input files to define a model instead of a Python function
         self.function = function
         self.fixed_anc_size = fixed_anc_size
         super(CustomDemographicModel, self).__init__(

--- a/tests/test_data.py
+++ b/tests/test_data.py
@@ -304,7 +304,7 @@ class TestDataHolder(unittest.TestCase):
     @pytest.mark.timeout(0)
     def test_vcf_data_reading(self):
         for engine in all_engines():
-            if engine.id != "momentsLD":
+            if engine.id not in ("momentsLD", "fsc2"):
                 self._test_vcf_reading(engine.id)
 
     @unittest.skipIf(DADI_NOT_AVAILABLE, "Dadi module is not installed")
@@ -402,7 +402,7 @@ def test_fsc_reading():
                     continue
 
             fsc_data = engine.read_data(fsc_data_holder)
-            vcf_data = engine.read_data(vcf_data_holder)
+            vcf_data = engine.read_data(vcf_data_holder) if engine.id != "fsc2" else np.empty(1)
 
             debug = False
             if debug:
@@ -429,8 +429,9 @@ def test_fsc_reading():
                 delta = np.sum(np.abs(fsc_data - vcf_data))
                 assert delta <= 4, "difference between SFSs is larger than expected"
 
-            assert fsc_data.folded == vcf_data.folded, \
-                    test.file + ": folded did not match"
+            if engine.id != 'fsc2':
+                assert fsc_data.folded == vcf_data.folded, \
+                        test.file + ": folded did not match"
 
         # test the case with multiple observations per file
         multiple = SFSDataHolder(

--- a/tests/test_engines.py
+++ b/tests/test_engines.py
@@ -449,6 +449,9 @@ class TestEngines(unittest.TestCase):
 
     def test_evaluating_engines(self):
         data_holder = self.get_data_holder()
+        sfs_data_holder = SFSDataHolder(
+            str(Path(DATA_PATH, "DATA", "fsc", "DSFS.obs"))
+        )
         dm = self.get_model()
 
         values = [var.resample() for var in dm.variables]
@@ -463,7 +466,7 @@ class TestEngines(unittest.TestCase):
                 kwargs["pts"] = [5, 10, 15]  # pts
 
             if engine.can_evaluate:
-                engine.data = data_holder
+                engine.data = data_holder if engine.id != "fsc2" else sfs_data_holder
                 engine.model = dm
                 engine.evaluate(values, **kwargs)
 

--- a/tests/test_optimizers.py
+++ b/tests/test_optimizers.py
@@ -552,7 +552,7 @@ class TestCoreRun(unittest.TestCase):
 
         for engine in all_engines():
             print(engine.id)
-            if engine.id != "momentsLD":
+            if engine.id not in ("momentsLD", "fsc2"):
                 try:
                     settings = SettingsStorage()
                     settings.engine = engine.id
@@ -617,6 +617,23 @@ class TestCoreRun(unittest.TestCase):
                         "vcf_ld", "small",
                         "preprocessed_data.bp"
                     )
+                    settings.is_valid()
+                    gadma.core.core.job(0, shared_dict, settings)
+                finally:
+                    if check_dir_existence("Some_out_dir"):
+                        shutil.rmtree("Some_out_dir")
+            elif engine.id == "fsc2":
+                try:
+                    # TODO: Choose the best settings for fsc2
+                    settings = SettingsStorage()
+                    settings.engine = engine.id
+                    settings.output_directory = "Some_out_dir"
+                    settings.num_init_const = 2
+                    settings.global_maxiter = 4
+                    settings.local_maxiter = 1
+                    settings.model_plot_engine = "demes"
+                    sfs_file = os.path.join(DATA_PATH, "DATA", "fsc", 'jointDAFpop1_0.obs')
+                    settings.input_data = f"{sfs_file}"
                     settings.is_valid()
                     gadma.core.core.job(0, shared_dict, settings)
                 finally:


### PR DESCRIPTION
- Added a new evaluating engine -- [fastsimcoal2](http://cmpg.unibe.ch/software/fastsimcoal2/).
  - To use this engine, user should specify the path to fastsimcoal2 executable via  `FSC2_PATH` environmental variable.
  - This engine accepts site frequency spectrum data in form of `.obs` files. In cases of one or two populations, the engine uses a normal `.obs` file format; if there's more than two populations, the engine uses multiSFS format instead
  - Supported model types: `TreeDemographicModel`, `EpochDemographicModel` (translated into the former). It is also possible to specify a model using native fsc2 file formats; in this case the engine can accept them via a `CustomDemographicModel`.
  - fastsimcoal2 doesn't support linear growth, so the engine doesn't support it as well.
  - Migration is not supported at the moment.
- Added test cases for the new engine.

**Note:** a lot of commits have a `[skip ci]` label in commit messages. If those commits shouldn't skip CI, then please tell me and I will remove them (or you can remove them themselves).